### PR TITLE
Fix for whitespace before comment block

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -321,7 +321,7 @@ Parser.prototype._findElements = function(block)
 	block = block.replace(/\n/g, "\uffff");
 
 	// Elements start with @
-	var elementsRegExp = /(@(\w*)\s?(.+?)(?=\uffff@|$))/gm;
+	var elementsRegExp = /(@(\w*)\s?(.+?)(?=\uffff[\s\*]*@|$))/gm;
 	var matches = elementsRegExp.exec(block);
 	while(matches)
 	{


### PR DESCRIPTION
Fixes a bug when comment block has whitespace before it which causes a crash
e.g.

```
/**
 * @apiDefinePermission admin This title is visible in version 0.1.0 and 0.2.0
 * @apiVersion 0.1.0
 */

    /**
     * @api {get} /user/:id Read data of a User
     * @apiVersion 0.3.0
     * @apiName GetUser
     * @apiGroup User
     */
```
