### PR TITLE
Fix parsing for empty lines and removing stars on data that spans over multiple lines.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -262,7 +262,7 @@ Parser.prototype._findBlocks = function()
 
 	// Entfernt in den gefundenen Blöcken die überflüssigen " * " und "   " am Anfang.
 	//var starsRegExp = /^\s?(\*|\s)?\s?/gm;
-	var starsRegExp = /^\s?(\*|\s)[ ]?/gm;
+	var starsRegExp = /^(\s+)?(\*|\s)[ ]?/gm;
 
 	// Findet die Dokumentblöcke zwischen "/**" und "*/"
 	var docBlocksRegExp = /\/\*\*\uffff(.+?)\*\//g;


### PR DESCRIPTION
Fix parsing problems for data spanning over multiple lines, it didn't remove the stars.
Also empty lines would cause apiGroup to include star i the name.

These problems only occurs when you have your block comments indented.

Example.

```
/**
 * @api {get} /user/:id Read data of a User
 * @apiVersion 0.3.0
 * @apiName GetUser
 * @apiGroup User
 *
 */

    /**
     * @api {post} /user Create user
     * @apiVersion 0.3.0
     * @apiName GetUser
     * @apiGroup User
     *
     * @apiParam {Object} foo
     *
     * @apiDescription first line
     * second line
     */
```
