### PR TITLE
Give some indication, in case file listing with fails

### DIFF
--- a/lib/utils/find_files.js
+++ b/lib/utils/find_files.js
@@ -59,6 +59,9 @@ function findFiles(options)
 			return 1;
 		}); // files.filter
 	} // try
+	catch (e) {
+		console.warn(e);
+	} // catch
 	finally
 	{
 		if( ! files || files.length === 0)


### PR DESCRIPTION
In case wrench throws an exception during file listing,
this gives some indication, why the file array is empty.
