### PR TITLE
Fix parsing of python multiline string

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -292,7 +292,7 @@ Parser.prototype._findBlocks = function()
 
 		case ".py":
 			// Find document blocks between """ and """
-			docBlocksRegExp = /\"\"\"\uffff(.+?)\"\"\"/g;
+			docBlocksRegExp = /\"\"\"\uffff?(.+?)\"\"\"/g;
 			// Remove not needed "	" (tabs) at the beginning
 			inlineRegExp = /^(\t+)?[ ]?/gm;
 			break;


### PR DESCRIPTION
Fixes issue #34

Python multiline string syntax can legally be used on a single line. This patch recognises this in the apidoc parser.
