### PR TITLE
Adding http: to fonts.googleapis.com link href

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -4,7 +4,7 @@
 	<title>apiDoc</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-	<link href="//fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro:400,600,700" rel="stylesheet" type="text/css">
+	<link href="http://fonts.googleapis.com/css?family=Source+Code+Pro|Source+Sans+Pro:400,600,700" rel="stylesheet" type="text/css">
 	<link href="vendor/bootstrap.min.css" rel="stylesheet" media="screen">
 	<link href="vendor/prettify.css" rel="stylesheet" media="screen">
 	<link href="css/style.css" rel="stylesheet" media="screen">


### PR DESCRIPTION
Original href without leading `http:` does NOT work on local computers
