### PR TITLE
Support for multiple input folders.  

### DIFF
--- a/lib/apidoc.js
+++ b/lib/apidoc.js
@@ -264,6 +264,31 @@ function createOutputFiles(parsedFiles, parsedFilenames, packageInfos)
 	if( ! options.simulate) fs.writeFileSync(options.dest + "./api_project.js", "define(" + json + ");");
 } // createOutputFiles
 
+
+/**
+ * Parse files in specified folder.
+ * @param {Object} parser Util to parse the files.
+ * @param {Object} options The options used to parse and filder the files.
+ * @param {Object[]} parsedFiles List of parsed files.
+ * @param {String[]} parsedFilenames List of parsed files, with full path.
+ */
+function parseFiles(parser, options, parsedFiles, parsedFilenames)
+{
+    var files = findFiles(options);
+	// Parser
+	for(var i = 0; i < files.length; i += 1)
+	{
+	  	var filename = options.src + files[i];
+	   	var parsedFile = parser.parseFile(filename);
+	   	if(parsedFile)
+	   	{
+	 	   app.log("parse file: " + filename);
+   	       parsedFiles.push(parsedFile);
+   		   parsedFilenames.push(filename);
+  	    }
+    } // for
+}
+
 /**
  * Main
  *
@@ -278,7 +303,6 @@ function main(defaults)
 	markdown.setOptions(options.marked);
 
 	// Paths
-	options.src      = path.join(options.src, "./");
 	options.dest     = path.join(options.dest, "./");
 	options.template = path.join(options.template, "./");
 
@@ -288,7 +312,6 @@ function main(defaults)
 	_.defaults(options.parsers, app.parsers);
 	_.defaults(options.workers, app.workers);
 
-	var files = findFiles(options);
 	var parser = new Parser(app);
 	var parsedFiles = [];
 	var parsedFilenames = [];
@@ -297,19 +320,25 @@ function main(defaults)
 
 	try
 	{
-		// Parser
-		for(var i = 0; i < files.length; i += 1)
+		// If input option for source is an array of folders, 
+		// parse each folder in the order provided.
+		if (options.src instanceof Array)
 		{
-			var filename = options.src + files[i];
-			var parsedFile = parser.parseFile(filename);
-			if(parsedFile)
+			options.src.forEach(function(folder)
 			{
-				app.log("parse file: " + filename);
-
-				parsedFiles.push(parsedFile);
-				parsedFilenames.push(filename);
-			}
-		} // for
+			   // Keep same options for each folder, but ensure the "src" of options 
+			   // is the folder currently being processed.
+			   var folderOptions = options;
+			   folderOptions.src = path.join(folder, "./");
+			   parseFiles(parser, folderOptions, parsedFiles, parsedFilenames);
+		    });
+		 }
+		 else
+		 {
+		 	// If the input option for source is a single folder, parse as usual.
+		 	options.src = path.join(options.src, "./");
+            parseFiles(parser, options, parsedFiles, parsedFilenames);
+		 }
 
 		// Worker / Filter
 		if(parsedFiles.length > 0)


### PR DESCRIPTION
When multiple entries are provided for `-i` in options, all provided folders will be parsed in the order provided.

This functionality is useful when re-using definitions across multiple web API docs.  The common definitions can be parsed first and then the API specifics can provided in a second folder.
Ex:
`apidoc -i example/ -i example2/ -o doc/`
