### PR TITLE
fixed issues with apiName values with apostrophes

### DIFF
--- a/lib/plugins/parser_api_name.js
+++ b/lib/plugins/parser_api_name.js
@@ -5,8 +5,7 @@ function parse(content)
 
 	if(content.length === 0) return null;
 	return {
-		name: content.replace(/(\s|'+)/g, "_")
-	};
+		name: content.replace(/(\s+|'|:|\.|\[|\])/g, "_")
 } // parse
 
 function pushTo()


### PR DESCRIPTION
jQuery don't recognize selector's with symbol ', we shouldescape this special character too
