### PR TITLE
Add parameter example type

### DIFF
--- a/lib/apidoc.js
+++ b/lib/apidoc.js
@@ -113,6 +113,7 @@ var app = {
         apiinfotitle             : "./parsers/api_info_title.js",
         apiname                  : "./parsers/api_name.js",
         apiparam                 : "./parsers/api_param.js",
+        apiparamexample          : "./parsers/api_param_example.js",
         apiparamtitle            : "./parsers/api_param_title.js",
         apipermission            : "./parsers/api_permission.js",
         apistructure             : "./parsers/api_structure.js",

--- a/lib/parsers/api_param_example.js
+++ b/lib/parsers/api_param_example.js
@@ -1,0 +1,15 @@
+// Same as @apiexample
+var apiExample = require("./api_example.js");
+
+function pushTo()
+{
+    return "local.parameter.examples";
+}
+
+/**
+ * Exports.
+ */
+module.exports = {
+    parse: apiExample.parse,
+    pushTo: pushTo
+};

--- a/test/fixtures/api_data.js
+++ b/test/fixtures/api_data.js
@@ -145,6 +145,20 @@ define({ api: [
         "type": "JS"
       }
     ],
+    "parameter": {
+      "examples": [
+        {
+          "title": "PHP Parameter Example (new)",
+          "content": "echo 'This is the parameter content. (new)';\n",
+          "type": "PHP"
+        },
+        {
+          "title": "JS Parameter Example",
+          "content": "console.log('This is the parameter content.');\n",
+          "type": "JS"
+        }
+      ]
+    },
     "success": {
       "examples": [
         {
@@ -195,6 +209,20 @@ define({ api: [
         "type": "JS"
       }
     ],
+    "parameter": {
+      "examples": [
+        {
+          "title": "PHP Parameter Example",
+          "content": "echo 'This is the parameter content.';\n",
+          "type": "PHP"
+        },
+        {
+          "title": "JS Parameter Example (removed)",
+          "content": "console.log('This is the parameter content. (removed)');\n",
+          "type": "JS"
+        }
+      ]
+    },
     "success": {
       "examples": [
         {

--- a/test/fixtures/api_data.json
+++ b/test/fixtures/api_data.json
@@ -145,6 +145,20 @@
         "type": "JS"
       }
     ],
+    "parameter": {
+      "examples": [
+        {
+          "title": "PHP Parameter Example (new)",
+          "content": "echo 'This is the parameter content. (new)';\n",
+          "type": "PHP"
+        },
+        {
+          "title": "JS Parameter Example",
+          "content": "console.log('This is the parameter content.');\n",
+          "type": "JS"
+        }
+      ]
+    },
     "success": {
       "examples": [
         {
@@ -195,6 +209,20 @@
         "type": "JS"
       }
     ],
+    "parameter": {
+      "examples": [
+        {
+          "title": "PHP Parameter Example",
+          "content": "echo 'This is the parameter content.';\n",
+          "type": "PHP"
+        },
+        {
+          "title": "JS Parameter Example (removed)",
+          "content": "console.log('This is the parameter content. (removed)');\n",
+          "type": "JS"
+        }
+      ]
+    },
     "success": {
       "examples": [
         {

--- a/test/fixtures/example/example.js
+++ b/test/fixtures/example/example.js
@@ -10,6 +10,11 @@
  * @apiExample {JS} JS Example
  * console.log('This is the content.');
  *
+ * @apiParamExample {PHP} PHP Parameter Example (new)
+ * echo 'This is the parameter content. (new)';
+ * @apiParamExample {JS} JS Parameter Example
+ * console.log('This is the parameter content.');
+ *
  * @apiSuccessExample {PHP} PHP Success Example (new)
  * echo 'This is the success content. (new)';
  * @apiSuccessExample {JS} JS Success Example
@@ -32,6 +37,11 @@
  * echo 'This is the content.';
  * @apiExample {JS} JS Example (removed)
  * console.log('This is the content. (removed)');
+ *
+ * @apiParamExample {PHP} PHP Parameter Example
+ * echo 'This is the parameter content.';
+ * @apiParamExample {JS} JS Parameter Example (removed)
+ * console.log('This is the parameter content. (removed)');
  *
  * @apiSuccessExample {PHP} PHP Success Example
  * echo 'This is the success content.';


### PR DESCRIPTION
Parameter example type, useful if you want to provide an example
request body or parameter examples.
