### PR TITLE
Correctly handle Erlang comments

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -322,10 +322,9 @@ Parser.prototype._findBlocks = function()
         },
         ".erl": {
             // Find document blocks between "%{" and "%}"
-            docBlocksRegExp: /\%\{\uffff?(.+?)\%\}/g,
+            docBlocksRegExp: /\%+\{\uffff?(.+?)\%+\}/g,
             // Remove not needed " % " and "	" (tabs) at the beginning
-            // HINT: Not sure if erlang developer use the %, but i think it should be no problem
-            inlineRegExp: /^(\t+)?(\%)[ ]?/gm
+            inlineRegExp: /^(\t+)?(\%+)[ ]?/gm
         },
         ".py": {
             // Find document blocks between """ and """


### PR DESCRIPTION
Erlangers tend to use multi-comment-starters to denote different types of comments, i.e. inline-, function- or header-comments. e.g:

``` erlang
%%% @doc Hi!
-module(hi).

%%@doc Function x
function x() -> y.
```

This commit supports one or many `%`
