### PR TITLE
Allow multiple spaces in @apiExample

### DIFF
--- a/lib/parsers/api_example.js
+++ b/lib/parsers/api_example.js
@@ -8,7 +8,7 @@ function parse(content, source)
 	var type;
 
 	// Search for [@apiexample title] and content
-	var parseRegExp = /^(@\w*)?\s?(?:(?:\{(.+?)\})\s*)?(.*)$/gm;
+	var parseRegExp = /^(@\w*)?\s*(?:(?:\{(.+?)\})\s*)?(.*)$/gm;
 
     var matches;
 	while(matches = parseRegExp.exec(source))


### PR DESCRIPTION
I've had a bunch of people try to use the following:

```
@apiExample        {curl}      Title goes here
```

They are trying to line up all the bracket-y stuff, and I figured rather than ask everyone to change it, I'd do a pull request. (I didn't see a good place to write a test for this; let me know if I missed it)
