### PR TITLE
Allows to include an external file which can set the markdown settings

### DIFF
--- a/bin/apidoc
+++ b/bin/apidoc
@@ -50,6 +50,9 @@ var argv = optimist
     .option('simulate', { boolean: true, 'default': false, describe: 'Execute but not write any file.' })
 
     // markdown settings
+    .option('marked-config',         { 'default': '',
+            describe: 'Enable custom markdown parser configs. It will overwite all other marked settings.' })
+
     .option('marked-gfm',         { boolean: true, 'default': true,
             describe: 'Enable GitHub flavored markdown.' })
 
@@ -103,6 +106,28 @@ function transformToObject(filters) {
     return result;
 }
 
+/**
+ * Sets configuration for markdown
+ *
+ * @param {Array} argv
+ * @returns {Object}
+ */
+function resolveMarkdownOptions(argv) {
+  if (argv['marked-config']) {
+    return require(path.resolve(argv['marked-config']));
+  } else {
+    return {
+      gfm:         argv['marked-gfm'],
+      tables:      argv['marked-tables'],
+      breaks:      argv['marked-breaks'],
+      pedantic:    argv['marked-pedantic'],
+      sanitize:    argv['marked-sanitize'],
+      smartLists:  argv['marked-smartLists'],
+      smartypants: argv['marked-smartypants']
+    };
+  }
+}
+
 var defaults = {
     excludeFilters: argv['exclude-filters'],
     includeFilters: argv['file-filters'],
@@ -117,15 +142,7 @@ var defaults = {
     workers:        transformToObject(argv['parse-workers']),
     silent:         argv['silent'],
     simulate:       argv['simulate'],
-    marked: {
-        gfm:         argv['marked-gfm'],
-        tables:      argv['marked-tables'],
-        breaks:      argv['marked-breaks'],
-        pedantic:    argv['marked-pedantic'],
-        sanitize:    argv['marked-sanitize'],
-        smartLists:  argv['marked-smartLists'],
-        smartypants: argv['marked-smartypants']
-    }
+    marked:         resolveMarkdownOptions(argv)
 };
 
 try {


### PR DESCRIPTION
Instead of providing the "marked" markdown settings through the apidoc binary i extended it with the ability to load an external file which allows to set the marked settings + extensions you want to the markdown parsing.

By doing:

```
apidoc --marked-config markdown_config.js
```

and have a file "markdown_config.js":

```
// Be including marked here we could overwrite the renderer really easy
var marked = require('apidoc/node_modules/marked');
var myRenderer = new marked.Renderer();

// A lot of the markdown rendering function can be altered this way
// eg: below we add target blank for each external link
myRenderer.link = function(href, title, text) {
  var external, newWindow, out;
  external = /^https?:\/\/.+$/.test(href);
  newWindow = external || title === 'newWindow';
  out = "<a href=\"" + href + "\"";
  if (newWindow) {
    out += ' target="_blank"';
  }
  if (title && title !== 'newWindow') {
    out += " title=\"" + title + "\"";
  }
  return out += ">" + text + "</a>";
};

// options can be set as wanted
module.exports = {
  gfm: true,
  tables: true,
  breaks: false,
  pedantic: false,
  sanitize: false,
  smartLists: false,
  silent: false,
  highlight: null,
  langPrefix: '',
  smartypants: false,
  headerPrefix: '',
  renderer: myRenderer,
  xhtml: false
};
```
