### PR TITLE
allowed options.packageInfo to overwrite default packageInfo

### DIFF
--- a/lib/package_info.js
+++ b/lib/package_info.js
@@ -37,6 +37,9 @@ PackageInfo.prototype.get = function() {
     // apidoc.json has higher priority
     _.defaults(packageInfo, packageJsonInfo);
 
+    // options.packageInfo overwrites packageInfo
+    _.extend(packageInfo, app.options.packageInfo);
+    
     if (Object.keys(packageInfo).length === 0)
         app.log.warning('Please create an apidoc.json.');
 


### PR DESCRIPTION
Allowed `options.packageInfo` to overwrite default `packageInfo` so that environment specific options can be switched using `grunt-apidoc`'s task specific options.

The following example grunt task configuration can be used for `apidoc:dev`, `apidoc:staging`, `apidoc:production` tasks.

```
dev: {
  src: "api/",
  dest: "doc/",
  options: {
    packageInfo : {
      sampleUrl: "https://localhost:6443"
    }
  }
},
staging: {
  src: "api/",
  dest: "doc/",
  options: {
    packageInfo : {
      sampleUrl: "https://staging.api.domain:6443"
    }
  }
},
production: {
  src: "api/",
  dest: "doc/",
  options: {
    packageInfo : {
      sampleUrl: "https://api.domain"
    }
  }
}
```
