### PR TITLE
Sample requests should also support basic GET requests with standard que...

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -69,16 +69,43 @@ define([
       } // for
 
       // send AJAX request, catch success or error callback
-      $.ajax({
-          url: url,
-          dataType: "json",
-          contentType: "application/json",
-          data: JSON.stringify(param),
-          headers: header,
-          type: type.toUpperCase(),
-          success: displaySuccess,
-          error: displayError
-      });
+      if (type === "get") {
+        $.ajax({
+            url: url + paramToQueryParms(param),
+            dataType: "text",
+            contentType: "text/plain",
+            type: type.toUpperCase(),
+            success: displaySuccess,
+            error: displayError
+        });
+      } else {
+        $.ajax({
+            url: url,
+            dataType: "json",
+            contentType: "application/json",
+            data: JSON.stringify(param),
+            headers: header,
+            type: type.toUpperCase(),
+            success: displaySuccess,
+            error: displayError
+        });
+      }
+
+      function paramToQueryParms(param) {
+        var p = 0,
+            queryParms = "";
+        
+        for (var k in param) {
+          if (p === 0) {
+            queryParms += "?" + k + "=" + param[k];
+          } else {
+            queryParms += "&" + k + "=" + param[k];
+          }
+          p++;
+        }
+        
+        return queryParms;
+      }
 
       function displaySuccess(data) {
           var jsonResponse;


### PR DESCRIPTION
...ry parameters

Right now when doing sample requests with basic GET endpoints JSON stringified params are being appended to the end of the url rather than added as standard query params.  For example, when sending a sample request with sample data like var1 = 123 & var2 = 456 you get something like example.com/?{%22var1%22:%22123%22,%var2%22:%2245%22} instead of example.com/?var1=123&var2=456.