### PR TITLE
add a check to see if packageJson.apidoc was defined

### DIFF
--- a/lib/package_info.js
+++ b/lib/package_info.js
@@ -44,7 +44,7 @@ PackageInfo.prototype.get = function() {
     // replace header footer with file contents
     _.extend(result, this._getHeaderFooter(result));
 
-    if (Object.keys(apidocJson).length === 0)
+    if (Object.keys(apidocJson).length === 0 && _.isUndefined(packageJson.apidoc) === true)
         app.log.warn('Please create an apidoc.json.');
 
     return result;

--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -68,17 +68,24 @@ define([
           }
       } // for
 
-      // send AJAX request, catch success or error callback
-      $.ajax({
+      var ajaxRequest = {
           url: url,
-          dataType: "json",
-          contentType: "application/json",
-          data: JSON.stringify(param),
           headers: header,
           type: type.toUpperCase(),
           success: displaySuccess,
           error: displayError
-      });
+      };
+
+      if ( ajaxRequest.type !== "GET" ) {
+        ajaxRequest.dataType = "json";
+        ajaxRequest.data = JSON.stringify(param);
+        ajaxRequest.contentType = "application/json";
+      } else {
+        ajaxRequest.data = param;
+      }
+
+      // send AJAX request, catch success or error callback
+      $.ajax(ajaxRequest);
 
       function displaySuccess(data) {
           var jsonResponse;


### PR DESCRIPTION
When using package.json to define apidoc settings the apidoc command would still log a warning to create an apidoc.json.