### PR TITLE
add a check to see if packageJson.apidoc was defined

### DIFF
--- a/lib/package_info.js
+++ b/lib/package_info.js
@@ -44,7 +44,7 @@ PackageInfo.prototype.get = function() {
     // replace header footer with file contents
     _.extend(result, this._getHeaderFooter(result));
 
-    if (Object.keys(apidocJson).length === 0)
+    if (Object.keys(apidocJson).length === 0 && _.isUndefined(packageJson.apidoc) === true)
         app.log.warn('Please create an apidoc.json.');
 
     return result;

--- a/lib/package_info.js
+++ b/lib/package_info.js
@@ -44,7 +44,7 @@ PackageInfo.prototype.get = function() {
     // replace header footer with file contents
     _.extend(result, this._getHeaderFooter(result));
 
-    if (Object.keys(apidocJson).length === 0 && _.isUndefined(packageJson.apidoc) === true)
+    if (Object.keys(apidocJson).length === 0 && _.isUndefined(packageJson.apidoc))
         app.log.warn('Please create an apidoc.json.');
 
     return result;


### PR DESCRIPTION
When using package.json to define apidoc settings the apidoc command would still log a warning to create an apidoc.json.