### PR TITLE
Feature/multiple input locations

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+test/multi_input_folder/fixtures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # apiDoc Changelog
 
+#### 0.12.2
+* CLI
+  * Input Option -i can now be used with multiple locations `bin/apidoc -i common/ -i ../src`
+
 #### 0.12.1
 
 * CLI

--- a/bin/apidoc
+++ b/bin/apidoc
@@ -22,7 +22,7 @@ var argv = nomnom
     .option('exclude-filters', { abbr: 'e', 'default': '',
             help: 'RegEx-Filter to select files / dirs that should not be parsed (many -e can be used).', })
 
-    .option('input', { abbr: 'i', 'default': './', help: 'Input / source dirname.' })
+    .option('input', { abbr: 'i', 'default': './', help: 'Input / source dirname.', list: true })
 
     .option('output', { abbr: 'o', 'default': './doc/', help: 'Output dirname.' })
 

--- a/lib/package_info.js
+++ b/lib/package_info.js
@@ -60,7 +60,8 @@ PackageInfo.prototype.get = function() {
  */
 PackageInfo.prototype._readPackageData = function(filename) {
     var result = {};
-    var jsonFilename = path.join(app.options.src, filename);
+    var dir = this._resolveSrcPath();
+    var jsonFilename = path.join(dir, filename);
 
     // read from source dir
     if ( ! fs.existsSync(jsonFilename)) {
@@ -89,9 +90,12 @@ PackageInfo.prototype._readPackageData = function(filename) {
 PackageInfo.prototype._getHeaderFooter = function(json) {
     var result = {};
 
+    var _this = this;
+
     ['header', 'footer'].forEach(function(key) {
         if (json[key] && json[key].filename) {
-            var filename = path.join(app.options.src, json[key].filename);
+            var dir = _this._resolveSrcPath();
+            var filename = path.join(dir, json[key].filename);
             if ( ! fs.existsSync(filename))
                 filename = path.join('./', json[key].filename);
 
@@ -109,4 +113,19 @@ PackageInfo.prototype._getHeaderFooter = function(json) {
     });
 
     return result;
+};
+
+/**
+ *
+ * @returns {string}
+ * @private
+ */
+PackageInfo.prototype._resolveSrcPath = function() {
+    var dir = './';
+
+    if (app.options.src instanceof Array && app.options.src.length === 1) {
+        dir = app.options.src[0];
+    }
+
+    return dir;
 };

--- a/test/multi_input_folder/apidoc_multifile_input_test.js
+++ b/test/multi_input_folder/apidoc_multifile_input_test.js
@@ -1,0 +1,92 @@
+/*jshint unused:false, expr:true */
+
+/**
+ * Test: apiDoc creation from multiple folder
+ */
+
+var fs = require('fs-extra');
+var exec = require('child_process').exec;
+var path = require('path');
+var should = require('should');
+
+describe('apiDoc multiple folder input', function() {
+
+    var fixturePath = 'test/multi_input_folder/fixtures';
+    var projectBaseBath = 'test/multi_input_folder/testproject';
+
+    var testTargetPath = "./tmp/apidocmulti";
+
+    var fixtureFiles = [
+        'api_data.js',
+        'api_data.json',
+        'api_project.js',
+        'api_project.json',
+        'index.html'
+    ];
+
+    before(function(done) {
+        fs.removeSync(testTargetPath);
+        done();
+    });
+
+    it('should create apidoc in /tmp/apidocmulti with multiple input folders', function(done) {
+
+        var commonDefinitions = path.join('', 'folder1');
+        var historyDefinition = path.join('', 'folder2');
+        var srcFolder = path.join('', 'src');
+
+        var cmd = 'cd ' + projectBaseBath + ' && ';
+        cmd += 'node ../../../bin/apidoc';
+        cmd += ' -i ' + commonDefinitions;
+        cmd += ' -i ' + historyDefinition;
+        cmd += ' -i ' + srcFolder;
+        cmd += ' -o ../../../tmp/apidocmulti';
+
+        exec(cmd, function(err, stdout, stderr) {
+            if (err)
+                throw err;
+
+            if (stderr)
+                throw stderr;
+
+            done();
+        });
+    });
+
+    it('created files should equal to fixtures', function(done) {
+        var timeRegExp = /\"time\"\:\s\"(.*)\"/g;
+        var versionRegExp = /\"version\"\:\s\"(.*)\"/g;
+        var filenameRegExp = new RegExp('(?!"filename":\\s")(' + projectBaseBath + '/)', 'g');
+
+        fixtureFiles.forEach(function(name) {
+            var fixtureContent = fs.readFileSync(path.join(fixturePath, name), 'utf8');
+            var createdContent = fs.readFileSync(path.join(testTargetPath, name), 'utf8');
+
+            // creation time remove (never equal)
+            fixtureContent = fixtureContent.replace(timeRegExp, '');
+            createdContent = createdContent.replace(timeRegExp, '');
+
+            // creation time remove (or fixtures must be updated every time the version change)
+            fixtureContent = fixtureContent.replace(versionRegExp, '');
+            createdContent = createdContent.replace(versionRegExp, '');
+
+            // remove the base path
+            createdContent = createdContent.replace(filenameRegExp, '');
+
+            var fixtureLines = fixtureContent.split(/\r\n/);
+            var createdLines = createdContent.split(/\r\n/);
+
+            if (fixtureLines.length !== createdLines.length)
+                throw new Error('File ' + path.join(testTargetPath, name) + ' not equals to ' + fixturePath + '/' + name);
+
+            for (var lineNumber = 0; lineNumber < fixtureLines.length; lineNumber += 1) {
+                if (fixtureLines[lineNumber] !== createdLines[lineNumber])
+                    throw new Error('File ' + path.join(testTargetPath, name) + ' not equals to ' + fixturePath + '/' + name + ' in line ' + (lineNumber + 1) +
+                        '\nfixture: ' + fixtureLines[lineNumber] +
+                        '\ncreated: ' + createdLines[lineNumber]
+                    );
+            }
+        });
+        done();
+    });
+});

--- a/test/multi_input_folder/fixtures/api_data.js
+++ b/test/multi_input_folder/fixtures/api_data.js
@@ -1,0 +1,144 @@
+define({ "api": [
+  {
+    "type": "post",
+    "url": "/api/authenticate",
+    "title": "",
+    "version": "0.3.0",
+    "group": "Authentication",
+    "name": "Authenticate",
+    "parameter": {
+      "fields": {
+        "Credentials": [
+          {
+            "group": "Credentials",
+            "type": "String",
+            "optional": false,
+            "field": "username",
+            "description": "<p>Username</p> "
+          },
+          {
+            "group": "Credentials",
+            "type": "String",
+            "optional": false,
+            "field": "password",
+            "description": "<p>password</p> "
+          }
+        ]
+      }
+    },
+    "filename": "src/test_api.js",
+    "groupTitle": "Authentication",
+    "error": {
+      "fields": {
+        "500 Internal Server Error": [
+          {
+            "group": "500 Internal Server Error",
+            "optional": false,
+            "field": "InternalServerError",
+            "description": "<p>The server encountered an internal error</p> "
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "500 Internal Server Error",
+          "content": "HTTP/1.1 500 Internal Server Error\n{\n    \"uri\": \"<api-endpoint>\",\n    \"method\": \"<method used>\",\n    \"type\": \"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n    \"title\": \"Internal Server Error\",\n    \"status\": 500,\n    \"detail\": \"<Detail Message>\"\n}",
+          "type": "json"
+        }
+      ]
+    }
+  },
+  {
+    "type": "get",
+    "url": "/api/subscriptioninfo",
+    "title": "",
+    "version": "0.3.0",
+    "description": "<p>Get the subscription information from an authenticated user.</p> ",
+    "group": "Authentication",
+    "name": "GetSubscriptionInfo",
+    "filename": "src/test_api.js",
+    "groupTitle": "Authentication",
+    "header": {
+      "fields": {
+        "Header": [
+          {
+            "group": "Header",
+            "type": "String",
+            "optional": false,
+            "field": "Authorization",
+            "description": "<p>Auth header with JWT Token</p> "
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Authorization-Example:",
+          "content": "Authorization: Bearer <jwt-token>",
+          "type": "String"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "500 Internal Server Error": [
+          {
+            "group": "500 Internal Server Error",
+            "optional": false,
+            "field": "InternalServerError",
+            "description": "<p>The server encountered an internal error</p> "
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "500 Internal Server Error",
+          "content": "HTTP/1.1 500 Internal Server Error\n{\n    \"uri\": \"<api-endpoint>\",\n    \"method\": \"<method used>\",\n    \"type\": \"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n    \"title\": \"Internal Server Error\",\n    \"status\": 500,\n    \"detail\": \"<Detail Message>\"\n}",
+          "type": "json"
+        }
+      ]
+    }
+  },
+  {
+    "type": "get",
+    "url": "/api/subscriptioninfo/:userid",
+    "title": "",
+    "version": "0.2.0",
+    "description": "<p>Get the subscription information for a user.</p> ",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": false,
+            "field": "userid",
+            "description": "<p>user id</p> "
+          }
+        ]
+      }
+    },
+    "group": "Authentication",
+    "name": "GetSubscriptionInfo",
+    "filename": "folder2/History.js",
+    "groupTitle": "Authentication",
+    "error": {
+      "fields": {
+        "500 Internal Server Error": [
+          {
+            "group": "500 Internal Server Error",
+            "optional": false,
+            "field": "InternalServerError",
+            "description": "<p>The server encountered an internal error</p> "
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "500 Internal Server Error",
+          "content": "HTTP/1.1 500 Internal Server Error\n{\n    \"uri\": \"<api-endpoint>\",\n    \"method\": \"<method used>\",\n    \"type\": \"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n    \"title\": \"Internal Server Error\",\n    \"status\": 500,\n    \"detail\": \"<Detail Message>\"\n}",
+          "type": "json"
+        }
+      ]
+    }
+  }
+] });

--- a/test/multi_input_folder/fixtures/api_data.json
+++ b/test/multi_input_folder/fixtures/api_data.json
@@ -1,0 +1,144 @@
+[
+  {
+    "type": "post",
+    "url": "/api/authenticate",
+    "title": "",
+    "version": "0.3.0",
+    "group": "Authentication",
+    "name": "Authenticate",
+    "parameter": {
+      "fields": {
+        "Credentials": [
+          {
+            "group": "Credentials",
+            "type": "String",
+            "optional": false,
+            "field": "username",
+            "description": "<p>Username</p> "
+          },
+          {
+            "group": "Credentials",
+            "type": "String",
+            "optional": false,
+            "field": "password",
+            "description": "<p>password</p> "
+          }
+        ]
+      }
+    },
+    "filename": "src/test_api.js",
+    "groupTitle": "Authentication",
+    "error": {
+      "fields": {
+        "500 Internal Server Error": [
+          {
+            "group": "500 Internal Server Error",
+            "optional": false,
+            "field": "InternalServerError",
+            "description": "<p>The server encountered an internal error</p> "
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "500 Internal Server Error",
+          "content": "HTTP/1.1 500 Internal Server Error\n{\n    \"uri\": \"<api-endpoint>\",\n    \"method\": \"<method used>\",\n    \"type\": \"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n    \"title\": \"Internal Server Error\",\n    \"status\": 500,\n    \"detail\": \"<Detail Message>\"\n}",
+          "type": "json"
+        }
+      ]
+    }
+  },
+  {
+    "type": "get",
+    "url": "/api/subscriptioninfo",
+    "title": "",
+    "version": "0.3.0",
+    "description": "<p>Get the subscription information from an authenticated user.</p> ",
+    "group": "Authentication",
+    "name": "GetSubscriptionInfo",
+    "filename": "src/test_api.js",
+    "groupTitle": "Authentication",
+    "header": {
+      "fields": {
+        "Header": [
+          {
+            "group": "Header",
+            "type": "String",
+            "optional": false,
+            "field": "Authorization",
+            "description": "<p>Auth header with JWT Token</p> "
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "Authorization-Example:",
+          "content": "Authorization: Bearer <jwt-token>",
+          "type": "String"
+        }
+      ]
+    },
+    "error": {
+      "fields": {
+        "500 Internal Server Error": [
+          {
+            "group": "500 Internal Server Error",
+            "optional": false,
+            "field": "InternalServerError",
+            "description": "<p>The server encountered an internal error</p> "
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "500 Internal Server Error",
+          "content": "HTTP/1.1 500 Internal Server Error\n{\n    \"uri\": \"<api-endpoint>\",\n    \"method\": \"<method used>\",\n    \"type\": \"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n    \"title\": \"Internal Server Error\",\n    \"status\": 500,\n    \"detail\": \"<Detail Message>\"\n}",
+          "type": "json"
+        }
+      ]
+    }
+  },
+  {
+    "type": "get",
+    "url": "/api/subscriptioninfo/:userid",
+    "title": "",
+    "version": "0.2.0",
+    "description": "<p>Get the subscription information for a user.</p> ",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "Number",
+            "optional": false,
+            "field": "userid",
+            "description": "<p>user id</p> "
+          }
+        ]
+      }
+    },
+    "group": "Authentication",
+    "name": "GetSubscriptionInfo",
+    "filename": "folder2/History.js",
+    "groupTitle": "Authentication",
+    "error": {
+      "fields": {
+        "500 Internal Server Error": [
+          {
+            "group": "500 Internal Server Error",
+            "optional": false,
+            "field": "InternalServerError",
+            "description": "<p>The server encountered an internal error</p> "
+          }
+        ]
+      },
+      "examples": [
+        {
+          "title": "500 Internal Server Error",
+          "content": "HTTP/1.1 500 Internal Server Error\n{\n    \"uri\": \"<api-endpoint>\",\n    \"method\": \"<method used>\",\n    \"type\": \"http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n    \"title\": \"Internal Server Error\",\n    \"status\": 500,\n    \"detail\": \"<Detail Message>\"\n}",
+          "type": "json"
+        }
+      ]
+    }
+  }
+]

--- a/test/multi_input_folder/fixtures/api_project.js
+++ b/test/multi_input_folder/fixtures/api_project.js
@@ -1,0 +1,13 @@
+define({
+  "name": "Multiple Input Folder Test",
+  "version": "1.0.0",
+  "description": "Example of feeding apidoc from multiple input folder locations",
+  "sampleUrl": false,
+  "apidoc": "0.2.0",
+  "generator": {
+    "name": "apidoc",
+    "time": "2015-04-08T18:31:22.414Z",
+    "url": "http://apidocjs.com",
+    "version": "0.12.1"
+  }
+});

--- a/test/multi_input_folder/fixtures/api_project.json
+++ b/test/multi_input_folder/fixtures/api_project.json
@@ -1,0 +1,13 @@
+{
+  "name": "Multiple Input Folder Test",
+  "version": "1.0.0",
+  "description": "Example of feeding apidoc from multiple input folder locations",
+  "sampleUrl": false,
+  "apidoc": "0.2.0",
+  "generator": {
+    "name": "apidoc",
+    "time": "2015-04-08T18:31:22.414Z",
+    "url": "http://apidocjs.com",
+    "version": "0.12.1"
+  }
+}

--- a/test/multi_input_folder/fixtures/index.html
+++ b/test/multi_input_folder/fixtures/index.html
@@ -1,0 +1,658 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Loading...</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <link href="vendor/bootstrap.min.css" rel="stylesheet" media="screen">
+  <link href="vendor/prettify.css" rel="stylesheet" media="screen">
+  <link href="css/style.css" rel="stylesheet" media="screen, print">
+  <link href="img/favicon.ico" rel="icon" type="image/x-icon">
+  <script src="vendor/polyfill.js"></script>
+</head>
+<body>
+
+<script id="template-sidenav" type="text/x-handlebars-template">
+<nav id="scrollingNav">
+  <ul class="sidenav nav nav-list">
+  {{#each nav}}
+    {{#if title}}
+      {{#if isHeader}}
+        {{#if isFixed}}
+          <li class="nav-fixed nav-header" data-group="{{group}}"><a href="#api-{{group}}">{{underscoreToSpace title}}</a></li>
+        {{else}}
+          <li class="nav-header" data-group="{{group}}"><a href="#api-{{group}}">{{underscoreToSpace title}}</a></li>
+        {{/if}}
+      {{else}}
+        <li {{#if hidden}}class="hide" {{/if}}data-group="{{group}}" data-name="{{name}}" data-version="{{version}}">
+          <a href="#api-{{group}}-{{name}}">{{title}}</a>
+        </li>
+      {{/if}}
+    {{/if}}
+  {{/each}}
+  </ul>
+</nav>
+</script>
+
+<script id="template-project" type="text/x-handlebars-template">
+  <div class="pull-left">
+    <h1>{{name}}</h1>
+    {{#if description}}<h2>{{{nl2br description}}}</h2>{{/if}}
+  </div>
+  {{#if template.withCompare}}
+  <div class="pull-right">
+    <div class="btn-group">
+      <button id="version" class="btn btn-large dropdown-toggle" data-toggle="dropdown">
+        <strong>{{version}}</strong> <span class="caret"></span>
+      </button>
+      <ul id="versions" class="dropdown-menu open-left">
+          <li><a id="compareAllWithPredecessor" href="#">{{__ "Compare all with predecessor"}}</a></li>
+          <li class="divider"></li>
+          <li class="disabled"><a href="#">{{__ "show up to version:"}}</a></li>
+  {{#each versions}}
+        <li class="version"><a href="#">{{this}}</a></li>
+  {{/each}}
+      </ul>
+    </div>
+  </div>
+  {{/if}}
+  <div class="clearfix"></div>
+</script>
+
+<script id="template-header" type="text/x-handlebars-template">
+  {{#if content}}
+    <div id="api-_">{{{content}}}</div>
+  {{/if}}
+</script>
+
+<script id="template-footer" type="text/x-handlebars-template">
+  {{#if content}}
+    <div id="api-_footer">{{{content}}}</div>
+  {{/if}}
+</script>
+
+<script id="template-generator" type="text/x-handlebars-template">
+  {{#if template.withGenerator}}
+    {{#if generator}}
+      <div class="content">
+        {{__ "Generated with"}} <a href="{{{generator.url}}}">{{{generator.name}}}</a> {{{generator.version}}} - {{{generator.time}}}
+      </div>
+    {{/if}}
+  {{/if}}
+</script>
+
+<script id="template-sections" type="text/x-handlebars-template">
+  <section id="api-{{group}}">
+    <h1>{{underscoreToSpace title}}</h1>
+    {{#if description}}
+      <p>{{{nl2br description}}}</p>
+    {{/if}}
+    {{#each articles}}
+      <div id="api-{{group}}-{{name}}">
+        {{{article}}}
+      </div>
+    {{/each}}
+  </section>
+</script>
+
+<script id="template-article" type="text/x-handlebars-template">
+  <article id="api-{{article.group}}-{{article.name}}-{{article.version}}" {{#if hidden}}class="hide"{{/if}} data-group="{{article.group}}" data-name="{{article.name}}" data-version="{{article.version}}">
+    <div class="pull-left">
+      <h1>{{article.groupTitle}}{{#if article.title}} - {{article.title}}{{/if}}</h1>
+    </div>
+    {{#if template.withCompare}}
+    <div class="pull-right">
+      <div class="btn-group">
+        <button class="version btn dropdown-toggle" data-toggle="dropdown">
+          <strong>{{article.version}}</strong> <span class="caret"></span>
+        </button>
+        <ul class="versions dropdown-menu open-left">
+          <li class="disabled"><a href="#">{{__ "compare changes to:"}}</a></li>
+  {{#each versions}}
+          <li class="version"><a href="#">{{this}}</a></li>
+  {{/each}}
+        </ul>
+      </div>
+    </div>
+    {{/if}}
+    <div class="clearfix"></div>
+
+    {{#if article.description}}
+      <p>{{{nl2br article.description}}}</p>
+    {{/if}}
+
+    <pre class="prettyprint language-html" data-type="{{toLowerCase article.type}}"><code>{{article.url}}</code></pre>
+
+    {{#if article.permission}}
+      <p>
+        {{__ "Permission:"}}
+        {{#each article.permission}}
+          {{name}}
+          {{#if title}}
+            &nbsp;<a href="#" data-toggle="popover" data-placement="right" data-html="true" data-content="{{nl2br description}}" title="" data-original-title="{{title}}"><span class="label label-info"><i class="icon icon-info-sign icon-white"></i></span></a>
+            {{#unless @last}}, {{/unless}}
+          {{/if}}
+        {{/each}}
+      </p>
+    {{/if}}
+
+    {{#if_gt article.examples.length compare=0}}
+      <ul class="nav nav-tabs nav-tabs-examples">
+        {{#each article.examples}}
+          <li{{#if_eq @index compare=0}} class="active"{{/if_eq}}>
+            <a href="#examples-{{../id}}-{{@index}}">{{title}}</a>
+          </li>
+        {{/each}}
+      </ul>
+
+      <div class="tab-content">
+      {{#each article.examples}}
+        <div class="tab-pane{{#if_eq @index compare=0}} active{{/if_eq}}" id="examples-{{../id}}-{{@index}}">
+          <pre class="prettyprint language-{{type}}" data-type="{{type}}"><code>{{content}}</code></pre>
+        </div>
+      {{/each}}
+      </div>
+    {{/if_gt}}
+
+    {{subTemplate "article-param-block" params=article.header _hasType=_hasTypeInHeaderFields section="header"}}
+    {{subTemplate "article-param-block" params=article.parameter _hasType=_hasTypeInParameterFields section="parameter"}}
+    {{subTemplate "article-param-block" params=article.success _hasType=_hasTypeInSuccessFields section="success"}}
+    {{subTemplate "article-param-block" params=article.error _col1="Name" _hasType=_hasTypeInErrorFields section="error"}}
+
+    {{subTemplate "article-sample-request" article=article id=id}}
+
+  </article>
+</script>
+
+<script id="template-article-param-block" type="text/x-handlebars-template">
+  {{#if params}}
+    {{#each params.fields}}
+      <h2>{{__ @key}}</h2>
+      <table>
+        <thead>
+          <tr>
+            <th style="width: 30%">{{#if _col1}}{{__ _col1}}{{else}}{{__ "Field"}}{{/if}}</th>
+            {{#if ../../_hasType}}<th style="width: 10%">{{__ "Type"}}</th>{{/if}}
+            <th style="width: {{#if _hasType}}60%{{else}}70%{{/if}}">{{__ "Description"}}</th>
+          </tr>
+        </thead>
+        <tbody>
+      {{#each this}}
+          <tr>
+            <td class="code">{{{splitFill field "." "&nbsp;&nbsp;"}}}{{#if optional}} <span class="label label-optional">{{__ "optional"}}</span>{{/if}}</td>
+            {{#if ../../_hasType}}
+              <td>
+                {{{type}}}
+              </td>
+            {{/if}}
+            <td>
+            {{{nl2br description}}}
+            {{#if defaultValue}}<p class="default-value">{{__ "Default value:"}} <code>{{{defaultValue}}}</code></p>{{/if}}
+            {{#if size}}<p class="type-size">{{__ "Size range:"}} <code>{{{size}}}</code></p>{{/if}}
+            {{#if allowedValues}}<p class="type-size">{{__ "Allowed values:"}}
+              {{#each allowedValues}}
+                <code>{{{this}}}</code>{{#unless @last}}, {{/unless}}
+              {{/each}}
+              </p>
+            {{/if}}
+            </td>
+          </tr>
+      {{/each}}
+        </tbody>
+      </table>
+    {{/each}}
+
+    {{#if_gt params.examples.length compare=0}}
+      <ul class="nav nav-tabs nav-tabs-examples">
+        {{#each params.examples}}
+          <li{{#if_eq @index compare=0}} class="active"{{/if_eq}}>
+            <a href="#{{../section}}-examples-{{../id}}-{{@index}}">{{title}}</a>
+          </li>
+        {{/each}}
+      </ul>
+
+      <div class="tab-content">
+      {{#each params.examples}}
+        <div class="tab-pane{{#if_eq @index compare=0}} active{{/if_eq}}" id="{{../section}}-examples-{{../id}}-{{@index}}">
+        <pre class="prettyprint language-{{type}}" data-type="{{type}}"><code>{{content}}</code></pre>
+        </div>
+      {{/each}}
+      </div>
+    {{/if_gt}}
+
+  {{/if}}
+</script>
+
+<script id="template-article-sample-request" type="text/x-handlebars-template">
+    {{#if article.sampleRequest}}
+      <h2>{{__ "Send a Sample Request"}}</h2>
+      <form class="form-horizontal">
+        <fieldset>
+          <div class="control-group">
+            <div class="controls">
+              <div class="input-prepend">>
+                <span class="add-on">{{__ "url"}}</span>
+                <input type="text" class="input-xxlarge sample-request-url" value="{{article.sampleRequest.0.url}}" />
+              </div>
+            </div>
+          </div>
+
+      {{#if article.header}}
+        {{#if article.header.fields}}
+          <h3>{{__ "Headers"}}</h3>
+          {{#each article.header.fields}}
+            <h4><input type="radio" data-sample-request-header-group-id="sample-request-header-{{@index}}" name="{{../id}}-sample-request-header" value="{{@index}}" class="sample-request-header sample-request-switch"{{#if_eq @index compare=0}} checked{{/if_eq}}> {{@key}}</h4>
+            <div class="{{../id}}-sample-request-header-fields{{#if_gt @index compare=0}} hide{{/if_gt}}">
+              {{#each this}}
+              <div class="control-group">
+                <label class="control-label" for="sample-request-header-field-{{field}}">{{field}}</label>
+                <div class="controls">
+                  <div class="input-append">>
+                    <input type="text" placeholder="{{field}}" class="input-xxlarge sample-request-header" data-sample-request-header-name="{{field}}" data-sample-request-header-group="sample-request-header-{{@../index}}">
+                    <span class="add-on">{{type}}</span>
+                  </div>
+                </div>
+              </div>
+              {{/each}}
+            </div>
+          {{/each}}
+        {{/if}}
+      {{/if}}
+
+      {{#if article.parameter}}
+        {{#if article.parameter.fields}}
+          <h3>{{__ "Parameters"}}</h3>
+          {{#each article.parameter.fields}}
+            <h4><input type="radio" data-sample-request-param-group-id="sample-request-param-{{@index}}"  name="{{../id}}-sample-request-param" value="{{@index}}" class="sample-request-param sample-request-switch"{{#if_eq @index compare=0}} checked{{/if_eq}}> {{@key}}</h4>
+            <div class="{{../id}}-sample-request-param-fields{{#if_gt @index compare=0}} hide{{/if_gt}}">
+              {{#each this}}
+              <div class="control-group">
+                <label class="control-label" for="sample-request-param-field-{{field}}">{{field}}</label>
+                <div class="controls">
+                  <div class="input-append">>
+                    <input type="text" placeholder="{{field}}" class="input-xxlarge sample-request-param" data-sample-request-param-name="{{field}}" data-sample-request-param-group="sample-request-param-{{@../index}}">
+                    <span class="add-on">{{type}}</span>
+                  </div>
+                </div>
+              </div>
+              {{/each}}
+            </div>
+          {{/each}}
+        {{/if}}
+      {{/if}}
+
+          <div class="control-group">
+            <div class="controls">
+              <button class="btn btn-default sample-request-send" data-sample-request-type="{{article.type}}">{{__ "Send"}}</button>
+            </div>
+          </div>
+
+          <div class="sample-request-response" style="display: none;">
+            <h3>
+              {{__ "Response"}}
+              <button class="btn btn-small btn-default pull-right sample-request-clear">X</button>
+            </h3>
+            <pre class="prettyprint language-json" data-type="json"><code class="sample-request-response-json"></code></pre>
+          </div>
+
+        </fieldset>
+      </form>
+    {{/if}}
+</script>
+
+<script id="template-compare-article" type="text/x-handlebars-template">
+  <article id="api-{{article.group}}-{{article.name}}-{{article.version}}" {{#if hidden}}class="hide"{{/if}} data-group="{{article.group}}" data-name="{{article.name}}" data-version="{{article.version}}" data-compare-version="{{compare.version}}">
+    <div class="pull-left">
+      <h1>{{underscoreToSpace article.group}} - {{{showDiff article.title compare.title}}}</h1>
+    </div>
+
+    <div class="pull-right">
+      <div class="btn-group">
+        <button class="btn btn-success" disabled>
+          <strong>{{article.version}}</strong> {{__ "compared to"}}
+        </button>
+        <button class="version btn btn-danger dropdown-toggle" data-toggle="dropdown">
+          <strong>{{compare.version}}</strong> <span class="caret"></span>
+        </button>
+        <ul class="versions dropdown-menu open-left">
+          <li class="disabled"><a href="#">{{__ "compare changes to:"}}</a></li>
+          <li class="divider"></li>
+  {{#each versions}}
+          <li class="version"><a href="#">{{this}}</a></li>
+  {{/each}}
+        </ul>
+      </div>
+    </div>
+    <div class="clearfix"></div>
+
+    {{#if article.description}}
+      <p>{{{showDiff article.description compare.description "nl2br"}}}</p>
+    {{else}}
+      {{#if compare.description}}
+      <p>{{{showDiff "" compare.description "nl2br"}}}</p>
+      {{/if}}
+    {{/if}}
+
+    <pre class="prettyprint language-html" data-type="{{toLowerCase article.type}}"><code>{{{showDiff article.url compare.url}}}</code></pre>
+
+    {{subTemplate "article-compare-permission" article=article compare=compare}}
+
+    <ul class="nav nav-tabs nav-tabs-examples">
+    {{#each_compare_title article.examples compare.examples}}
+
+      {{#if typeSame}}
+        <li{{#if_eq index compare=0}} class="active"{{/if_eq}}>
+          <a href="#compare-examples-{{../../article.id}}-{{index}}">{{{showDiff source.title compare.title}}}</a>
+        </li>
+      {{/if}}
+
+      {{#if typeIns}}
+        <li{{#if_eq index compare=0}} class="active"{{/if_eq}}>
+          <a href="#compare-examples-{{../../article.id}}-{{index}}"><ins>{{{source.title}}}</ins></a>
+        </li>
+      {{/if}}
+
+      {{#if typeDel}}
+        <li{{#if_eq index compare=0}} class="active"{{/if_eq}}>
+          <a href="#compare-examples-{{../../article.id}}-{{index}}"><del>{{{compare.title}}}</del></a>
+        </li>
+      {{/if}}
+
+    {{/each_compare_title}}
+    </ul>
+
+    <div class="tab-content">
+    {{#each_compare_title article.examples compare.examples}}
+
+      {{#if typeSame}}
+        <div class="tab-pane{{#if_eq index compare=0}} active{{/if_eq}}" id="compare-examples-{{../../article.id}}-{{index}}">
+          <pre class="prettyprint language-{{source.type}}" data-type="{{source.type}}"><code>{{{showDiff source.content compare.content}}}</code></pre>
+        </div>
+      {{/if}}
+
+      {{#if typeIns}}
+        <div class="tab-pane{{#if_eq index compare=0}} active{{/if_eq}}" id="compare-examples-{{../../article.id}}-{{index}}">
+          <pre class="prettyprint language-{{source.type}}" data-type="{{source.type}}"><code>{{{source.content}}}</code></pre>
+        </div>
+      {{/if}}
+
+      {{#if typeDel}}
+        <div class="tab-pane{{#if_eq index compare=0}} active{{/if_eq}}" id="compare-examples-{{../../article.id}}-{{index}}">
+          <pre class="prettyprint language-{{source.type}}" data-type="{{compare.type}}"><code>{{{compare.content}}}</code></pre>
+        </div>
+      {{/if}}
+
+    {{/each_compare_title}}
+    </div>
+
+    {{subTemplate "article-compare-param-block" source=article.parameter compare=compare.parameter _hasType=_hasTypeInParameterFields section="parameter"}}
+    {{subTemplate "article-compare-param-block" source=article.success compare=compare.success _hasType=_hasTypeInSuccessFields section="success"}}
+    {{subTemplate "article-compare-param-block" source=article.error compare=compare.error _col1="Name" _hasType=_hasTypeInErrorFields section="error"}}
+
+    {{subTemplate "article-sample-request" article=article id=id}}
+
+  </article>
+</script>
+
+<script id="template-article-compare-permission" type="text/x-handlebars-template">
+  {{#each_compare_list_field article.permission compare.permission field="name"}}
+    {{#if source}}
+      {{#if typeSame}}
+        {{source.name}}
+        {{#if source.title}}
+          &nbsp;<a href="#" data-toggle="popover" data-placement="right" data-html="true" data-content="{{nl2br source.description}}" title="" data-original-title="{{source.title}}"><span class="label label-info"><i class="icon icon-info-sign icon-white"></i></span></a>
+          {{#unless _last}}, {{/unless}}
+        {{/if}}
+      {{/if}}
+
+      {{#if typeIns}}
+        <ins>{{source.name}}</ins>
+        {{#if source.title}}
+          &nbsp;<a href="#" data-toggle="popover" data-placement="right" data-html="true" data-content="{{nl2br source.description}}" title="" data-original-title="{{source.title}}"><span class="label label-info"><i class="icon icon-info-sign icon-white"></i></span></a>
+          {{#unless _last}}, {{/unless}}
+        {{/if}}
+      {{/if}}
+
+      {{#if typeDel}}
+        <del>{{source.name}}</del>
+        {{#if source.title}}
+          &nbsp;<a href="#" data-toggle="popover" data-placement="right" data-html="true" data-content="{{nl2br source.description}}" title="" data-original-title="{{source.title}}"><span class="label label-info"><i class="icon icon-info-sign icon-white"></i></span></a>
+          {{#unless _last}}, {{/unless}}
+        {{/if}}
+      {{/if}}
+    {{else}}
+      {{#if typeSame}}
+        {{compare.name}}
+        {{#if compare.title}}
+          &nbsp;<a href="#" data-toggle="popover" data-placement="right" data-html="true" data-content="{{nl2br compare.description}}" title="" data-original-title="{{compare.title}}"><span class="label label-info"><i class="icon icon-info-sign icon-white"></i></span></a>
+          {{#unless _last}}, {{/unless}}
+        {{/if}}
+      {{/if}}
+
+      {{#if typeIns}}
+        <ins>{{compare.name}}</ins>
+        {{#if compare.title}}
+          &nbsp;<a href="#" data-toggle="popover" data-placement="right" data-html="true" data-content="{{nl2br compare.description}}" title="" data-original-title="{{compare.title}}"><span class="label label-info"><i class="icon icon-info-sign icon-white"></i></span></a>
+          {{#unless _last}}, {{/unless}}
+        {{/if}}
+      {{/if}}
+
+      {{#if typeDel}}
+        <del>{{compare.name}}</del>
+        {{#if compare.title}}
+          &nbsp;<a href="#" data-toggle="popover" data-placement="right" data-html="true" data-content="{{nl2br compare.description}}" title="" data-original-title="{{compare.title}}"><span class="label label-info"><i class="icon icon-info-sign icon-white"></i></span></a>
+          {{#unless _last}}, {{/unless}}
+        {{/if}}
+      {{/if}}
+    {{/if}}
+  {{/each_compare_list_field}}
+</script>
+
+<script id="template-article-compare-param-block" type="text/x-handlebars-template">
+  {{#if source}}
+    {{#each_compare_keys source.fields compare.fields}}
+      {{#if typeSame}}
+        <h2>{{__ source.key}}</h2>
+        <table>
+        <thead>
+          <tr>
+            <th style="width: 30%">{{#if _col1}}{{__ _col1}}{{else}}{{__ "Field"}}{{/if}}</th>
+            {{#if ../../_hasType}}<th style="width: 10%">{{__ "Type"}}</th>{{/if}}
+            <th style="width: {{#if _hasType}}60%{{else}}70%{{/if}}">{{__ "Description"}}</th>
+          </tr>
+        </thead>
+        {{subTemplate "article-compare-param-block-body" source=source.value compare=compare.value _hasType=../../_hasType}}
+        </table>
+      {{/if}}
+
+      {{#if typeIns}}
+        <h2><ins>{{__ source.key}}</ins></h2>
+        <table class="ins">
+        <thead>
+          <tr>
+            <th style="width: 30%">{{#if _col1}}{{__ _col1}}{{else}}{{__ "Field"}}{{/if}}</th>
+            {{#if ../../_hasType}}<th style="width: 10%">{{__ "Type"}}</th>{{/if}}
+            <th style="width: {{#if _hasType}}60%{{else}}70%{{/if}}">{{__ "Description"}}</th>
+          </tr>
+        </thead>
+        {{subTemplate "article-compare-param-block-body" source=source.value compare=source.value _hasType=../../_hasType}}
+        </table>
+      {{/if}}
+
+      {{#if typeDel}}
+        <h2><del>{{__ compare.key}}</del></h2>
+        <table class="del">
+        <thead>
+          <tr>
+            <th style="width: 30%">{{#if _col1}}{{__ _col1}}{{else}}{{__ "Field"}}{{/if}}</th>
+            {{#if ../../_hasType}}<th style="width: 10%">{{__ "Type"}}</th>{{/if}}
+            <th style="width: {{#if _hasType}}60%{{else}}70%{{/if}}">{{__ "Description"}}</th>
+          </tr>
+        </thead>
+        {{subTemplate "article-compare-param-block-body" source=compare.value compare=compare.value _hasType=../../_hasType}}
+        </table>
+      {{/if}}
+    {{/each_compare_keys}}
+
+    <ul class="nav nav-tabs nav-tabs-examples">
+    {{#each_compare_title source.examples compare.examples}}
+
+      {{#if typeSame}}
+        <li{{#if_eq index compare=0}} class="active"{{/if_eq}}>
+          <a href="#{{../../section}}-compare-examples-{{../../article.id}}-{{index}}">{{{showDiff source.title compare.title}}}</a>
+        </li>
+      {{/if}}
+
+      {{#if typeIns}}
+        <li{{#if_eq index compare=0}} class="active"{{/if_eq}}>
+          <a href="#{{../../section}}-compare-examples-{{../../article.id}}-{{index}}"><ins>{{{source.title}}}</ins></a>
+        </li>
+      {{/if}}
+
+      {{#if typeDel}}
+        <li{{#if_eq index compare=0}} class="active"{{/if_eq}}>
+          <a href="#{{../../section}}-compare-examples-{{../../article.id}}-{{index}}"><del>{{{compare.title}}}</del></a>
+        </li>
+      {{/if}}
+
+    {{/each_compare_title}}
+    </ul>
+
+    <div class="tab-content">
+    {{#each_compare_title source.examples compare.examples}}
+
+      {{#if typeSame}}
+        <div class="tab-pane{{#if_eq index compare=0}} active{{/if_eq}}" id="{{../../section}}-compare-examples-{{../../article.id}}-{{index}}">
+          <pre class="prettyprint language-{{source.type}}" data-type="{{source.type}}"><code>{{{showDiff source.content compare.content}}}</code></pre>
+        </div>
+      {{/if}}
+
+      {{#if typeIns}}
+        <div class="tab-pane{{#if_eq index compare=0}} active{{/if_eq}}" id="{{../../section}}-compare-examples-{{../../article.id}}-{{index}}">
+          <pre class="prettyprint language-{{source.type}}" data-type="{{source.type}}"><code>{{{source.content}}}</code></pre>
+        </div>
+      {{/if}}
+
+      {{#if typeDel}}
+        <div class="tab-pane{{#if_eq index compare=0}} active{{/if_eq}}" id="{{../../section}}-compare-examples-{{../../article.id}}-{{index}}">
+          <pre class="prettyprint language-{{source.type}}" data-type="{{compare.type}}"><code>{{{compare.content}}}</code></pre>
+        </div>
+      {{/if}}
+
+    {{/each_compare_title}}
+    </div>
+
+  {{/if}}
+</script>
+
+<script id="template-article-compare-param-block-body" type="text/x-handlebars-template">
+  <tbody>
+    {{#each_compare_field source compare}}
+      {{#if typeSame}}
+        <tr>
+          <td class="code">
+            {{{splitFill source.field "." "&nbsp;&nbsp;"}}}
+            {{#if source.optional}}
+              {{#if compare.optional}} <span class="label label-optional">{{__ "optional"}}</span>
+              {{else}} <span class="label label-optional label-ins">{{__ "optional"}}</span>
+              {{/if}}
+            {{else}}
+              {{#if compare.optional}} <span class="label label-optional label-del">{{__ "optional"}}</span>{{/if}}
+            {{/if}}
+          </td>
+
+        {{#if source.type}}
+          {{#if compare.type}}
+          <td>{{{showDiff source.type compare.type}}}</td>
+          {{else}}
+          <td>{{{source.type}}}</td>
+          {{/if}}
+        {{else}}
+          {{#if compare.type}}
+          <td>{{{compare.type}}}</td>
+          {{else}}
+            {{#if ../../../../_hasType}}<td></td>{{/if}}
+          {{/if}}
+        {{/if}}
+          <td>
+            {{{showDiff source.description compare.description "nl2br"}}}
+            {{#if source.defaultValue}}<p class="default-value">{{__ "Default value:"}} <code>{{{showDiff source.defaultValue compare.defaultValue}}}</code><p>{{/if}}
+          </td>
+        </tr>
+      {{/if}}
+
+      {{#if typeIns}}
+        <tr class="ins">
+          <td class="code">
+            {{{splitFill source.field "." "&nbsp;&nbsp;"}}}
+            {{#if source.optional}} <span class="label label-optional label-ins">{{__ "optional"}}</span>{{/if}}
+          </td>
+
+        {{#if source.type}}
+          <td>{{{source.type}}}</td>
+        {{else}}
+          {{{typRowTd}}}
+        {{/if}}
+
+          <td>
+            {{{nl2br source.description}}}
+            {{#if source.defaultValue}}<p class="default-value">{{__ "Default value:"}} <code>{{{source.defaultValue}}}</code><p>{{/if}}
+          </td>
+        </tr>
+      {{/if}}
+
+      {{#if typeDel}}
+        <tr class="del">
+          <td class="code">
+            {{{splitFill compare.field "." "&nbsp;&nbsp;"}}}
+            {{#if compare.optional}} <span class="label label-optional label-del">{{__ "optional"}}</span>{{/if}}
+          </td>
+
+        {{#if compare.type}}
+          <td>{{{compare.type}}}</td>
+        {{else}}
+          {{{typRowTd}}}
+        {{/if}}
+
+          <td>
+            {{{nl2br compare.description}}}
+            {{#if compare.defaultValue}}<p class="default-value">{{__ "Default value:"}} <code>{{{compare.defaultValue}}}</code><p>{{/if}}
+          </td>
+        </tr>
+      {{/if}}
+
+    {{/each_compare_field}}
+  </tbody>
+</script>
+
+<div class="container-fluid">
+  <div class="row-fluid">
+    <div id="sidenav" class="span2"></div>
+    <div id="content">
+      <div id="project"></div>
+      <div id="header"></div>
+      <div id="sections"></div>
+      <div id="footer"></div>
+      <div id="generator"></div>
+    </div>
+  </div>
+</div>
+
+<div id="loader">
+  <div class="spinner">
+    <div class="spinner-container container1">
+      <div class="circle1"></div><div class="circle2"></div><div class="circle3"></div><div class="circle4"></div>
+    </div>
+    <div class="spinner-container container2">
+      <div class="circle1"></div><div class="circle2"></div><div class="circle3"></div><div class="circle4"></div>
+    </div>
+    <div class="spinner-container container3">
+      <div class="circle1"></div><div class="circle2"></div><div class="circle3"></div><div class="circle4"></div>
+    </div>
+    <p>Loading...</p>
+  </div>
+</div>
+
+<script data-main="main.js" src="vendor/require.min.js"></script>
+</body>
+</html>

--- a/test/multi_input_folder/testproject/apidoc.json
+++ b/test/multi_input_folder/testproject/apidoc.json
@@ -1,0 +1,5 @@
+{
+    "name": "Multiple Input Folder Test",
+    "version": "1.0.0",
+    "description": "Example of feeding apidoc from multiple input folder locations"
+}

--- a/test/multi_input_folder/testproject/folder1/AuthHeader.js
+++ b/test/multi_input_folder/testproject/folder1/AuthHeader.js
@@ -1,0 +1,7 @@
+/**
+ * @apiDefine AuthHeader
+ * @apiHeader {String} Authorization Auth header with JWT Token
+ *
+ * @apiHeaderExample {String} Authorization-Example:
+ * Authorization: Bearer <jwt-token>
+ */

--- a/test/multi_input_folder/testproject/folder1/DefaultErrors.js
+++ b/test/multi_input_folder/testproject/folder1/DefaultErrors.js
@@ -1,0 +1,28 @@
+/**
+ * @apiDefine Unauthorized
+ * @apiError (401 Unauthorized) Unauthorized Invalid or missing Authorization
+ * @apiErrorExample 401 Unauthorized:
+ * HTTP/1.1 401 Unauthorized
+ * {
+ *     "uri": "<api-endpoint>"
+ *     "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+ *     "title": "Unauthorized",
+ *     "status": 401,
+ *     "detail": "Invalid Authentication."
+ * }
+ */
+
+/**
+ * @apiDefine InternalServerError
+ * @apiError (500 Internal Server Error) InternalServerError The server encountered an internal error
+ * @apiErrorExample 500 Internal Server Error
+ * HTTP/1.1 500 Internal Server Error
+ * {
+ *     "uri": "<api-endpoint>",
+ *     "method": "<method used>",
+ *     "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+ *     "title": "Internal Server Error",
+ *     "status": 500,
+ *     "detail": "<Detail Message>"
+ * }
+ */

--- a/test/multi_input_folder/testproject/folder2/History.js
+++ b/test/multi_input_folder/testproject/folder2/History.js
@@ -1,0 +1,13 @@
+/**
+ * @api {get} /api/subscriptioninfo/:userid
+ * @apiVersion 0.2.0
+ *
+ * @apiDescription Get the subscription information for a user.
+ *
+ * @apiParam {Number} userid user id
+ *
+ * @apiGroup Authentication
+ * @apiName GetSubscriptionInfo
+ *
+ * @apiUse InternalServerError
+ */

--- a/test/multi_input_folder/testproject/src/test_api.js
+++ b/test/multi_input_folder/testproject/src/test_api.js
@@ -1,0 +1,26 @@
+/**
+ * @api {post} /api/authenticate
+ * @apiVersion 0.3.0
+ *
+ * @apiGroup Authentication
+ * @apiName Authenticate
+ *
+ * @apiParam (Credentials) {String} username Username
+ * @apiParam (Credentials) {String} password password
+ *
+ * @apiUse InternalServerError
+ */
+
+/**
+ * @api {get} /api/subscriptioninfo
+ * @apiVersion 0.3.0
+ *
+ * @apiDescription Get the subscription information from an authenticated user.
+ *
+ *
+ * @apiGroup Authentication
+ * @apiName GetSubscriptionInfo
+ *
+ * @apiUse AuthHeader
+ * @apiUse InternalServerError
+ */


### PR DESCRIPTION
The feature to have multiple input locations seems to got lost at some point during the further development of apidoc.

Example:
`apidoc -i defaultDefinitions/ - i defaultErrors/ -i mySource/ -o apidoc/`

##### Why
For me and the projects I'm working on it's a common use case. I missed this particular feature badly after upgrading to the latest version.

##### Code Changes
Changes to the code are few - the basic handling if the src is one or more files is already implemented.
My changes were minor: 
- flag the -i option to be a list, so one/many -i option(s) are stored in an array
- update the relevant code parts in `lib/package_info.js` to handle the options.src as an array

##### Proof
I created a testcase around the changes. I benefit from the current testcase where I could reuse a lot.

##### Improvements
There are a few improvements that could be added for locating the package.json for example.

Any feedback is appreciated.