### PR TITLE
'pathtoRegexp' is undefined in send_sample_request.js (line 59)

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -56,7 +56,7 @@ define([
       var url = $root.find(".sample-request-url").val();
 
       // Insert url parameter
-      var pattern = pathtoRegexp(url, null);
+      var pattern = pathToRegexp(url, null);
       var matches = pattern.exec(url);
       for (var i = 1; i < matches.length; i++) {
           var key = matches[i].substr(1);


### PR DESCRIPTION
I noticed sample requests were not working using the default template. Error in console was 'pathtoRegexp' undefined. 

'vendor/path-to-regexp/index.js' does not export a function called 'pathtoRegexp' but it does export function 'pathToRegexp'. Fixing the function call on line 59 of send_sample_request.js resolves the issue.

