### PR TITLE
Don't make sample requests with empty query params

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -73,7 +73,7 @@ define([
           url: url,
           dataType: "json",
           contentType: "application/json",
-          data: JSON.stringify(param),
+          data: $.isEmptyObject(param) ? null : JSON.stringify(param),
           headers: header,
           type: type.toUpperCase(),
           success: displaySuccess,


### PR DESCRIPTION
Currently requests get sent an empty object

e.g.
```
/user/1234?{}
```