### PR TITLE
Added a missing underscoreToSpace to template-article in template.html

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -56,7 +56,6 @@ Block 3 is the endpoint `/account/register`, which use parameters from `LoginPar
 Block 4 is the endpoint `/account/login`, which use only parameters from `LoginParam` and an extra checkbox.
 
 
-
 ### Example for a group
 
 ```js

--- a/template/index.html
+++ b/template/index.html
@@ -98,7 +98,7 @@
 <script id="template-article" type="text/x-handlebars-template">
   <article id="api-{{article.group}}-{{article.name}}-{{article.version}}" {{#if hidden}}class="hide"{{/if}} data-group="{{article.group}}" data-name="{{article.name}}" data-version="{{article.version}}">
     <div class="pull-left">
-      <h1>{{article.groupTitle}}{{#if article.title}} - {{article.title}}{{/if}}</h1>
+      <h1>{{underscoreToSpace article.groupTitle}}{{#if article.title}} - {{article.title}}{{/if}}</h1>
     </div>
     {{#if template.withCompare}}
     <div class="pull-right">


### PR DESCRIPTION
Without it if the group name had a space, it was replaced by an underscore in the header of the specific  API