### PR TITLE
Added Elixir support

### DIFF
--- a/bin/apidoc
+++ b/bin/apidoc
@@ -16,7 +16,7 @@ var nomnom = require('nomnom');
 var apidoc = require('../lib/index');
 
 var argv = nomnom
-    .option('file-filters', { abbr: 'f', 'default': '.*\\.(clj|coffee|cs|dart|erl|go|java|js|litcoffee|php?|py|rb|scala|ts|pm)$',
+    .option('file-filters', { abbr: 'f', 'default': '.*\\.(clj|coffee|cs|dart|erl|exs?|go|java|js|litcoffee|php?|py|rb|scala|ts|pm)$',
             list: true,
             help: 'RegEx-Filter to select files that should be parsed (multiple -f can be used).' })
 


### PR DESCRIPTION
Adds support for Elixir. Requires [#20](https://github.com/apidoc/apidoc-core/pull/20 "#20") in apidoc-core to be accepted.