### PR TITLE
Remove dataType: json from ajax line

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -71,7 +71,6 @@ define([
       // send AJAX request, catch success or error callback
       $.ajax({
           url: url,
-          dataType: "json",
           contentType: "application/json",
           data: JSON.stringify(param),
           headers: header,


### PR DESCRIPTION
This should prevent some errors from happening: when response from server is not JSON, an exception will happen.

