### PR TITLE
Escape and wrap output from sample request response

### DIFF
--- a/template/css/style.css
+++ b/template/css/style.css
@@ -235,6 +235,12 @@ pre code {
   white-space: pre;
 }
 
+pre code.sample-request-response-json {
+  white-space: pre-wrap;
+  max-height: 300px;
+  overflow: scroll;
+}
+
 /*
 pre.language-json {
   background: #f5f5f5;

--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -129,7 +129,7 @@ define([
               jsonResponse = JSON.parse(jqXHR.responseText);
               jsonResponse = JSON.stringify(jsonResponse, null, 4);
           } catch (e) {
-              jsonResponse = jqXHR.responseText;
+              jsonResponse = escape(jqXHR.responseText);
           }
 
           if (jsonResponse)


### PR DESCRIPTION
Some web frameworks like Phoenix render HTML output for debugging purposes while in development mode. This terribly messes up the DOM of the apidoc page.
It think, it's good to always escape the error output of the sample XHR if it can't be parsed as JSON and restrict the height of the sample output box.