### PR TITLE
make ajaxRequest simpler

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -77,38 +77,15 @@ define([
       // send AJAX request, catch success or error callback
       var ajaxRequest = {
           url        : url,
-          dataType   : "json",
-          contentType: "application/json",
           headers    : header,
+          data       : param,
           type       : type.toUpperCase(),
           success    : displaySuccess,
           error      : displayError
       };
 
-      if (type === 'get') {
-          ajaxRequest.url = url + paramToQueryParms(param),
-          ajaxRequest.dataType = "text";
-          ajaxRequest.contentType = "text/plain";
-      } else {
-          if ( ! $.isEmptyObject(param)) {
-              ajaxRequest.data = JSON.stringify(param);
-          }
-      }
       $.ajax(ajaxRequest);
 
-      function paramToQueryParms(param) {
-          var p = 0;
-          var queryParms = "";
-          for (var k in param) {
-              if (p === 0) {
-                  queryParms += "?" + k + "=" + param[k];
-              } else {
-                  queryParms += "&" + k + "=" + param[k];
-              }
-              p++;
-          }
-          return queryParms;
-      }
 
       function displaySuccess(data) {
           var jsonResponse;


### PR DESCRIPTION
By default, $.ajax's `dataType` is Intelligent Guess, which will try to infer it based on the MIME type of the response. Also, $.ajax will automatically convert `data` to query string if it's an object.

See also: http://api.jquery.com/jquery.ajax/