### PR TITLE
Allow for single source configuration

### DIFF
--- a/lib/package_info.js
+++ b/lib/package_info.js
@@ -128,8 +128,15 @@ PackageInfo.prototype._getHeaderFooter = function(json) {
 PackageInfo.prototype._resolveSrcPath = function() {
     var dir = './';
 
-    if (app.options.src instanceof Array && app.options.src.length === 1)
-        dir = app.options.src[0];
+    if (app.options.src instanceof Array) {
+        if (app.options.src.length === 1) {
+            dir = app.options.src[0];
+        }
+    } else {
+        if (app.options.src) {
+            dir = app.options.src;
+        }
+    }
 
     return dir;
 };


### PR DESCRIPTION
When invoking `apidoc.createDoc(options)` with `options.src = 'my/path'` the default (root) directory is chosen as the srcPath because it does not meet the criteria of being an Array. This can be circumvented by making the `options.src` an `[]` with one value but makes the simple case more complex for no good reason. 