### PR TITLE
Do not use monospace for sans-serif fonts, only code fonts.

### DIFF
--- a/template/css/style.css
+++ b/template/css/style.css
@@ -7,7 +7,7 @@ body {
 }
 
 body, p, a, div, th, td {
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 400;
   font-size: 16px;
 }
@@ -30,7 +30,7 @@ p {
 }
 
 h1 {
-  font-family: "Source Sans Pro Semibold", monospace, sans-serif;
+  font-family: "Source Sans Pro Semibold", sans-serif;
   font-weight: normal;
   font-size: 44px;
   line-height: 50px;
@@ -39,7 +39,7 @@ h1 {
 }
 
 h2 {
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: normal;
   font-size: 24px;
   line-height: 40px;
@@ -53,7 +53,7 @@ section {
 }
 
 section h1 {
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 700;
   font-size: 32px;
   line-height: 40px;
@@ -67,14 +67,14 @@ article {
 }
 
 article h1 {
-  font-family: "Source Sans Pro Bold", monospace, sans-serif;
+  font-family: "Source Sans Pro Bold", sans-serif;
   font-weight: 600;
   font-size: 24px;
   line-height: 26px;
 }
 
 article h2 {
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 600;
   font-size: 18px;
   line-height: 24px;
@@ -82,7 +82,7 @@ article h2 {
 }
 
 article h3 {
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 600;
   font-size: 16px;
   line-height: 18px;
@@ -90,7 +90,7 @@ article h3 {
 }
 
 article h4 {
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 600;
   font-size: 14px;
   line-height: 16px;
@@ -106,7 +106,7 @@ table {
 th {
   background-color: #f5f5f5;
   text-align: left;
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 700;
   padding: 4px 8px;
   border: #e0e0e0 1px solid;
@@ -143,7 +143,7 @@ td {
 }
 
 #apidoc h1 {
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 700;
   font-size: 32px;
   line-height: 40px;
@@ -153,7 +153,7 @@ td {
 }
 
 #apidoc h2 {
-  font-family: "Source Sans Pro Bold", monospace, sans-serif;
+  font-family: "Source Sans Pro Bold", sans-serif;
   font-weight: 600;
   font-size: 22px;
   line-height: 26px;
@@ -189,7 +189,7 @@ pre.language-html:before {
   position: absolute;
   top: -30px;
   left: 0;
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 600;
   font-size: 15px;
   display: inline-block;
@@ -228,7 +228,7 @@ pre.language-api .pun {
 pre code {
   display: block;
   font-size: 14px;
-  font-family: "Source Code Pro";
+  font-family: "Source Code Pro", monospace;
   font-style: normal;
   font-weight: 400;
   word-wrap: normal;
@@ -266,7 +266,7 @@ pre code.sample-request-response-json {
   border: 0;
   border-left: transparent 4px solid;
   border-right: transparent 4px solid;
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 400;
   font-size: 14px;
 }
@@ -275,7 +275,7 @@ pre code.sample-request-response-json {
   padding: 5px 15px;
   border: 1px solid #e5e5e5;
   width: 190px;
-  font-family: "Source Sans Pro", monospace, sans-serif;
+  font-family: "Source Sans Pro", sans-serif;
   font-weight: 700;
   font-size: 16px;
   background-color: #ffffff;


### PR DESCRIPTION
This is a followup to #414, I don't think you understood what I was asking for. Line 231 didn't have `monospace` for `pre` and `code` blocks so I've added that and removed the `monospace` fallback from all of the places where a `sans-serif` font was being used.