### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
   "version": "0.16.1",
   "description": "RESTful web API Documentation Generator",
   "author": "Peter Rottmann <rottmann@inveris.de>",
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/apidoc/apidoc/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "preferGlobal": true,
   "bin": "bin/apidoc",
   "main": "./lib/index.js",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)