### PR TITLE
Added support for private APIs

### DIFF
--- a/bin/apidoc
+++ b/bin/apidoc
@@ -32,6 +32,8 @@ var argv = nomnom
 
     .option('config', { abbr: 'c', 'default': './', help: 'Path to directory containing config file (apidoc.json)' })
 
+    .option('private', { abbr: 'p', 'default': false, help: 'Include private APIs in output.'})
+
     .option('verbose', { abbr: 'v', flag: true, 'default': false, help: 'Verbose debug output.' })
 
     .option('help', { abbr: 'h', flag: true, help: 'Show this help information.' })
@@ -92,6 +94,7 @@ var options = {
     dest          : argv['output'],
     template      : argv['template'],
     config        : argv['config'],
+    apiprivate    : argv['private'],
     verbose       : argv['verbose'],
     debug         : argv['debug'],
     parse         : argv['parse'],

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,15 +11,16 @@ var defaults = {
     dest    : path.join(__dirname, '../doc/'),
     template: path.join(__dirname, '../template/'),
 
-    debug   : false,
-    silent  : false,
-    verbose : false,
-    simulate: false,
-    parse   : false, // Only parse and return the data, no file creation.
-    colorize: true,
-    markdown: true,
-    config  : './',
-    encoding: 'utf8'
+    debug     : false,
+    silent    : false,
+    verbose   : false,
+    simulate  : false,
+    parse     : false, // Only parse and return the data, no file creation.
+    colorize  : true,
+    markdown  : true,
+    config    : './',
+    apiprivate: false,
+    encoding  : 'utf8'
 };
 
 var app = {


### PR DESCRIPTION
Added @apiPrivate to support the ability to specify
if an API is a private API.  apidoc now also has a
--private false|true parameter on the command line
that defaults to false.  If false, it does not include
any API block that contains @apiPrivate.  If true, it
will include the API (assuming the API is also not marked
as @apiIgnore).
