### PR TITLE
Custom parser to allow custom content types

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -101,7 +101,7 @@
 </script>
 
 <script id="template-article" type="text/x-handlebars-template">
-  <article id="api-{{article.group}}-{{article.name}}-{{article.version}}" {{#if hidden}}class="hide"{{/if}} data-group="{{article.group}}" data-name="{{article.name}}" data-version="{{article.version}}">
+  <article id="api-{{article.group}}-{{article.name}}-{{article.version}}" {{#if hidden}}class="hide"{{/if}} data-group="{{article.group}}" data-name="{{article.name}}" data-version="{{article.version}}" data-contenttype="{{article.contentType}}">
     <div class="pull-left">
       <h1>{{article.groupTitle}}{{#if article.title}} - {{article.title}}{{/if}}</h1>
     </div>

--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -12,7 +12,8 @@ define([
           var group = $root.data("group");
           var name = $root.data("name");
           var version = $root.data("version");
-          sendSampleRequest(group, name, version, $(this).data("sample-request-type"));
+          var contentType = $root.data("contenttype");
+          sendSampleRequest(group, name, version, $(this).data("sample-request-type"), contentType);
       });
 
       // Button clear
@@ -27,7 +28,7 @@ define([
       });
   }; // initDynamic
 
-  function sendSampleRequest(group, name, version, type)
+  function sendSampleRequest(group, name, version, type, contentType)
   {
       var $root = $('article[data-group="' + group + '"][data-name="' + name + '"][data-version="' + version + '"]');
 
@@ -81,15 +82,25 @@ define([
       $root.find(".sample-request-response-json").html("Loading...");
       refreshScrollSpy();
 
-      _.each( param, function( val, key ) {
-          var t = paramType[ key ].toLowerCase();
-          if ( t === 'object' || t === 'array' ) {
-              try {
-                  param[ key ] = JSON.parse( val );
-              } catch (e) {
+
+      if (!contentType && header['Content-Type']) {
+          contentType = header['Content-Type'];
+      }
+      header['Content-Type']=contentType;
+      if (contentType == 'application/json') {
+          param = JSON.stringify(param)
+      }
+      else {
+          _.each( param, function( val, key ) {
+              var t = paramType[ key ].toLowerCase();
+              if ( t === 'object' || t === 'array' ) {
+                  try {
+                      param[ key ] = JSON.parse( val );
+                  } catch (e) {
+                  }
               }
-          }
-      });
+          });
+      }
 
       // send AJAX request, catch success or error callback
       var ajaxRequest = {
@@ -98,6 +109,7 @@ define([
           data       : param,
           type       : type.toUpperCase(),
           success    : displaySuccess,
+          contentType: contentType,
           error      : displayError
       };
 

--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -86,6 +86,10 @@ define([
       if (!contentType && header['Content-Type']) {
           contentType = header['Content-Type'];
       }
+      else if(!contentType) {
+          //default
+          contentType = 'application/x-www-form-urlencoded; charset=UTF-8'
+      }
       header['Content-Type']=contentType;
       if (contentType == 'application/json') {
           param = JSON.stringify(param)


### PR DESCRIPTION
Hi,
I have seen a lot of people complaining about the impossibility to specify custom content types in their documentations, here is a parser. It can be used with `@apiContentType`, as metionned here: https://github.com/koko-ng/apidoc-contentType-plugin.
It needs https://github.com/apidoc/apidoc-core/pull/58 to work.
It uses part of https://github.com/apidoc/apidoc/pull/559/commits/4f0d291145f00dfdfaaa73180d43020749f5b3e1 code.