### PR TITLE
Add Docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 doc/
+docker-example/
 node_modules/
 tmp/
 npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:6-alpine
+
+RUN mkdir -p /apidoc
+WORKDIR /apidoc
+
+RUN npm install -g apidoc
+
+ENTRYPOINT ["apidoc"]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,28 @@ Documentation at [apidocjs.com](http://apidocjs.com) or as [Docset](https://gith
 
 ## Installation
 
-`npm install apidoc -g`
+```console
+$ npm install apidoc -g
+```
 
+### Alternative docker install
+
+```console
+$ docker pull apidoc/apidoc
+```
+
+Then you will need to mount your file storage `-v '<apidoc.json dir>:/apidoc'` to docker container.
+
+Example:
+
+```console
+$ docker run --rm -v '$(PWD):/apidoc' -it apidoc/apidoc \
+    --input ./example \
+    --output ./docker-example \
+    -v
+```
+
+Creates from input files in `example/` a documentation in path `docker-example/`.
 
 ## Changelog
 
@@ -40,7 +60,9 @@ Documentation at [apidocjs.com](http://apidocjs.com) or as [Docset](https://gith
  */
 ```
 
-`apidoc -i example/ -o doc/`
+```console
+$ apidoc -i example/ -o doc/
+```
 
 Creates from input files in `example/` a documentation in path `doc/`.
 


### PR DESCRIPTION
Thanks for apiDoc.

I've built a docker image as an alternative installation of apiDoc in environments without Node.js.

In case approval of this PR:

 - [ ] Create an automated build repo on Docker Hub based on https://github.com/apidoc/apidoc