### PR TITLE
Blank optional parameters omitted from sample request

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -274,7 +274,7 @@
               {{#each this}}
                 <label class="col-md-3 control-label" for="sample-request-param-field-{{field}}">{{field}}</label>
                 <div class="input-group">
-                  <input id="sample-request-param-field-{{field}}" type="text" placeholder="{{field}}" class="form-control sample-request-param" data-sample-request-param-name="{{field}}" data-sample-request-param-group="sample-request-param-{{@../index}}">
+                  <input id="sample-request-param-field-{{field}}" type="text" placeholder="{{field}}" class="form-control sample-request-param" data-sample-request-param-name="{{field}}" data-sample-request-param-group="sample-request-param-{{@../index}}" {{#if optional}}data-sample-request-param-optional="true"{{/if}}>
                   <div class="input-group-addon">{{{type}}}</div>
                 </div>
               {{/each}}

--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -50,7 +50,9 @@ define([
       var paramType = {};
       $root.find(".sample-request-param:checked").each(function(i, element) {
           var group = $(element).data("sample-request-param-group-id");
-          $root.find("[data-sample-request-param-group=\"" + group + "\"]").each(function(i, element) {
+          $root.find("[data-sample-request-param-group=\"" + group + "\"]").not(function(){
+            return $(this).val() == "" && $(this).is("[data-sample-request-param-optional='true']");
+          }).each(function(i, element) {
             var key = $(element).data("sample-request-param-name");
             var value = element.value;
             if ( ! element.optional && element.defaultValue !== '') {


### PR DESCRIPTION
This pull request alters sample request behavior so that `optional` parameter fields, when left blank, are omitted from sample requests.

This fixes problems with RESTFUL PUT APIs (edit record) so that it is only necessary to include parameters that need altering, instead of having to include every parameter where most are left unchanged. 