### PR TITLE
Sorting based on name rather than id

### DIFF
--- a/template/main.js
+++ b/template/main.js
@@ -806,8 +806,8 @@ require([
             if (splitBy)
                 elements.forEach (function(element) {
                     var parts = element.split(splitBy);
-                    var key = parts[1]; // reference keep for sorting
-                    if (key == name)
+                    var key = parts[0]; // reference keep for sorting
+                    if (key == name || parts[1] == name)
                         results.push(element);
                 });
             else


### PR DESCRIPTION
Hey, I had an issue while ordering endpoints based on name with spaces.
I realized that the sort comparison was done on the right part of the split which is the generated id.
This has no effect on name without space, but can be confusing :+1: 
My endpoint#~#My_endpoint

I therefore propose in this a way to handle sorting with spaces in @apiName (+ retro-compatibility in case of).