### PR TITLE
Bugfix: Avoid underscores in article group titles

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -103,7 +103,7 @@
 <script id="template-article" type="text/x-handlebars-template">
   <article id="api-{{article.group}}-{{article.name}}-{{article.version}}" {{#if hidden}}class="hide"{{/if}} data-group="{{article.group}}" data-name="{{article.name}}" data-version="{{article.version}}">
     <div class="pull-left">
-      <h1>{{article.groupTitle}}{{#if article.title}} - {{article.title}}{{/if}}</h1>
+      <h1>{{underscoreToSpace article.groupTitle}}{{#if article.title}} - {{article.title}}{{/if}}</h1>
     </div>
     {{#if template.withCompare}}
     <div class="pull-right">


### PR DESCRIPTION
underscoreToSpace was implemented almost everywhere, except on the group name in the title of articles. This is a minor bugfix in order to apply the underscoreToSpace helper to them.

Below was the original output before this tweak removed the underscore:
![capture](https://user-images.githubusercontent.com/7294642/48762004-f50d9d00-eca1-11e8-9cc7-6de3ed243b39.PNG)
