### PR TITLE
Support copyDefinitions apicore option with a --no-copy command line …

### DIFF
--- a/bin/apidoc
+++ b/bin/apidoc
@@ -28,7 +28,7 @@ var argv = cmd
 
     .option('-c, --config <config>', 'Path to directory containing config file (apidoc.json).', './')
 
-    .option('--no-copy', 'Do not copy API structure definitions.', false)
+    .option('--definitions', 'Include definitions file rather than copying definitions.', false)
 
     .option('-p, --private', 'Include private APIs in output.', false)
 
@@ -114,7 +114,7 @@ var options = {
     markdown      : argv.markdown,
     lineEnding    : argv.lineEnding,
     encoding      : argv.encoding,
-    copyDefinitions: !argv.noCopy
+    copyDefinitions: !argv.definitions,
 };
 
 if (apidoc.createDoc(options) === false) {

--- a/bin/apidoc
+++ b/bin/apidoc
@@ -28,6 +28,8 @@ var argv = cmd
 
     .option('-c, --config <config>', 'Path to directory containing config file (apidoc.json).', './')
 
+    .option('--no-copy', 'Do not copy API structure definitions.', false)
+
     .option('-p, --private', 'Include private APIs in output.', false)
 
     .option('-v, --verbose', 'Verbose debug output.', false)
@@ -111,7 +113,8 @@ var options = {
     simulate      : argv.simulate,
     markdown      : argv.markdown,
     lineEnding    : argv.lineEnding,
-    encoding      : argv.encoding
+    encoding      : argv.encoding,
+    copyDefinitions: !argv.noCopy
 };
 
 if (apidoc.createDoc(options) === false) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,6 +173,15 @@ function createOutputFiles(api) {
     app.log.verbose('write js file: ' + app.options.dest + 'api_project.js');
     if( ! app.options.simulate)
         fs.writeFileSync(app.options.dest + './api_project.js', 'define(' + api.project + ');' + '\n');
+
+    // Write api_definitions
+    app.log.verbose('write json file: ' + app.options.dest + 'api_definitions.json');
+    if( ! app.options.simulate && ! app.options.copyDefinitions)
+        fs.writeFileSync(app.options.dest + './api_definition.json', api.definitions + '\n');
+
+    app.log.verbose('write js file: ' + app.options.dest + 'api_definitions.js');
+    if( ! app.options.simulate && ! app.options.copyDefinitions)
+        fs.writeFileSync(app.options.dest + './api_definition.js', 'define({ "api": ' + api.definitions + ' });' + '\n');
 }
 
 module.exports = {


### PR DESCRIPTION
…option and write the corresponding definitions.json file.