### PR TITLE
Better handling of non-json ajax response.

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -112,9 +112,9 @@ define([
               jsonResponse = JSON.parse(jqXHR.responseText);
               jsonResponse = JSON.stringify(jsonResponse, null, 4);
           } catch (e) {
-              jsonResponse = data;
+              jsonResponse = jqXHR.responseText;
           }
-          $root.find(".sample-request-response-json").html(jsonResponse);
+          $root.find(".sample-request-response-json").text(jsonResponse);
           refreshScrollSpy();
       };
 
@@ -125,18 +125,18 @@ define([
               jsonResponse = JSON.parse(jqXHR.responseText);
               jsonResponse = JSON.stringify(jsonResponse, null, 4);
           } catch (e) {
-              jsonResponse = escape(jqXHR.responseText);
+              jsonResponse = jqXHR.responseText;
           }
 
           if (jsonResponse)
-              message += "<br>" + jsonResponse;
+              message += "\n" + jsonResponse;
 
           // flicker on previous error to make clear that there is a new response
           if($root.find(".sample-request-response").is(":visible"))
               $root.find(".sample-request-response").fadeTo(1, 0.1);
 
           $root.find(".sample-request-response").fadeTo(250, 1);
-          $root.find(".sample-request-response-json").html(message);
+          $root.find(".sample-request-response-json").text(message);
           refreshScrollSpy();
       };
   }


### PR DESCRIPTION
Hi there... great Project! +1 

If response is non-json, but for example xml... then the output is not readable. 

This commit fix this (its also dom-safe)