### PR TITLE
Adding base href to template head

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title>Loading...</title>
+  <script>
+    var base = document.createElement('base');
+    var href = window.location.href;
+    if (!href.endsWith('/')) {
+      href += '/'
+    }
+    base.href = href;
+    document.getElementsByTagName('head')[0].appendChild(base)
+  </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <link href="vendor/bootstrap.min.css" rel="stylesheet" media="screen">

--- a/template/index.html
+++ b/template/index.html
@@ -5,7 +5,7 @@
   <title>Loading...</title>
   <script>
     var base = document.createElement('base');
-    var href = window.location.href.split('#')[0];
+    var href = window.location.href.split(/[#?]/)[0];
     if (!href.endsWith('/')) {
       href += '/'
     }

--- a/template/index.html
+++ b/template/index.html
@@ -5,7 +5,7 @@
   <title>Loading...</title>
   <script>
     var base = document.createElement('base');
-    var href = window.location.href;
+    var href = window.location.href.split('#')[0];
     if (!href.endsWith('/')) {
       href += '/'
     }


### PR DESCRIPTION
I use `koa-static` to host the apidoc in my api server. Because apidoc index.html do not have `<base>` tag. I can access the apidoc index.html through https://xxxx.com/apidoc/, but I cannot access other files through https://xxxx.com/apidoc/vendor. 

I added a script to template index.html head. So that, index.html could create `<base>` tag automatically by `window.location.href`.