### PR TITLE
update apidoc core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "apidoc-core": "~0.8.3",
+    "apidoc-core": "~0.11.0",
     "commander": "^2.20.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
I create this pull request because I got an issue when I install last release of apidoc (0.19.0), I got apidoc-core 0.8.3 and not 0.11.0.

the feature filter-by is related to the last version of apidoc-core (0.11.0), I tried it in different environments and got always the same problème.

with the ~ it takes only patch version and no minor.

Thanks.
