### PR TITLE
handle parsing fields

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -107,6 +107,15 @@ define([
             }
         } // for
 
+        //handle arrays fields
+        Object.keys(paramType).forEach(function (key) {
+            if (paramType[key].endsWith('[]')) {
+                try {
+                    param[key] = JSON.parse(JSON.parse(param[key]));
+                } catch (e) {;}
+            }
+        });
+
 
         //add url search parameter
         if (header['Content-Type'] == 'application/json' ){

--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -111,7 +111,7 @@ define([
         Object.keys(paramType).forEach(function (key) {
             if (paramType[key].endsWith('[]')) {
                 try {
-                    param[key] = JSON.parse(JSON.parse(param[key]));
+                    param[key] = JSON.parse(param[key]);
                 } catch (e) {;}
             }
         });

--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -108,18 +108,8 @@ define([
             }
         } // for
 
-        //handle nested fields
-        param = utils.handleNestedFields(param, paramType);
-
-        //handle arrays fields
-        Object.keys(paramType).forEach(function (key) {
-            if (paramType[key].endsWith('[]')) {
-                try {
-                    param[key] = JSON.parse(param[key]);
-                } catch (e) {;}
-            }
-        });
-
+        //handle nested objects and parsing fields
+        param = utils.handleNestedAndParsingFields(param, paramType);
 
         //add url search parameter
         if (header['Content-Type'] == 'application/json' ){

--- a/template/utils/send_sample_request_utils.js
+++ b/template/utils/send_sample_request_utils.js
@@ -29,5 +29,23 @@ define([], function () {
         return result
     }
 
-    return {handleNestedFields: handleNestedFieldsForAllParams};
+    function handleArraysAndObjectFields(param, paramType) {
+        var result = Object.assign({}, param);
+        Object.keys(paramType).forEach(function (key) {
+            if (result[key] && (paramType[key].endsWith('[]') || paramType[key] === 'Object')) {
+                try {
+                    result[key] = JSON.parse(result[key]);
+                } catch (e) {;}
+            }
+        });
+        return result
+    }
+
+    function handleNestedAndParsingFields(param, paramType) {
+        var result = handleArraysAndObjectFields(param, paramType);
+        result = handleNestedFieldsForAllParams(result, paramType);
+        return result;
+    }
+
+    return {handleNestedAndParsingFields};
 });

--- a/test/template_tests.js
+++ b/test/template_tests.js
@@ -44,7 +44,7 @@ describe('send sample request utils', function () {
             }
         };
 
-        var result = sendSampleRequestUtils.handleNestedFields(param, paramType);
+        var result = sendSampleRequestUtils.handleNestedAndParsingFields(param, paramType);
         should.deepEqual(result, expectedResult);
         done();
     });
@@ -65,7 +65,7 @@ describe('send sample request utils', function () {
             'profile.birthday.year': 'Number',
         };
 
-        var result = sendSampleRequestUtils.handleNestedFields(param, paramType);
+        var result = sendSampleRequestUtils.handleNestedAndParsingFields(param, paramType);
         should.deepEqual(result, param);
         done();
     });
@@ -86,9 +86,88 @@ describe('send sample request utils', function () {
             'profile.birthday.year': 'Number',
         };
 
-        var result = sendSampleRequestUtils.handleNestedFields(param, paramType);
+        var result = sendSampleRequestUtils.handleNestedAndParsingFields(param, paramType);
         should.deepEqual(result, param);
         done();
     });
 
+    it('should handle array of strings field', function (done) {
+        var param = {
+            names: '["john","doe"]',
+        };
+
+        var paramType = {
+            names: 'String[]',
+        };
+
+        var expectedResult = {
+            names: ['john', 'doe'],
+        };
+
+        var result = sendSampleRequestUtils.handleNestedAndParsingFields(param, paramType);
+        should.deepEqual(result, expectedResult);
+        done();
+    });
+
+    it('should handle Object and array of objects field', function (done) {
+        var param = {
+            data: '{"a":1,"b":"b"}',
+            arrayData: '[{"a":1},{"a":2}]'
+        };
+
+        var paramType = {
+            data: 'Object',
+            arrayData: 'Object[]',
+        };
+
+        var expectedResult = {
+            data: {a: 1, b: "b"},
+            arrayData: [{"a": 1}, {"a": 2}]
+        };
+
+        var result = sendSampleRequestUtils.handleNestedAndParsingFields(param, paramType);
+        should.deepEqual(result, expectedResult);
+        done();
+    });
+
+    it('should handle nested fields and parse array and object', function (done) {
+        var param = {
+            'profile': '',
+            'profile.name': 'john doe',
+            'profile.birthday': '',
+            'profile.birthday.day': 10,
+            'profile.birthday.year': 2030,
+            'profile.info': '',
+            'profile.info.skills': '["js","node"]',
+            'profile.info.job': '{"company":"piedpiper"}',
+        };
+        var paramType = {
+            'profile': 'Object',
+            'profile.name': 'String',
+            'profile.birthday': 'Object',
+            'profile.birthday.day': 'Number',
+            'profile.birthday.year': 'Number',
+            'profile.info': 'Object',
+            'profile.info.skills': 'String[]',
+            'profile.info.job': 'Object',
+        };
+
+        var expectedResult = {
+            profile: {
+                name: param['profile.name'],
+                birthday: {
+                    day: param['profile.birthday.day'],
+                    year: param['profile.birthday.year']
+                },
+                info: {
+                    skills: ["js", "node"],
+                    job: {company: 'piedpiper'}
+                }
+            }
+        };
+
+        var result = sendSampleRequestUtils.handleNestedAndParsingFields(param, paramType);
+        should.deepEqual(result, expectedResult);
+        done();
+    });
 });


### PR DESCRIPTION
fixing #549 #642 #689 and a part of #627

With this modifications users have to put a valid JSON in the array field in order to send and array instead of a String in the request body.
Example: for this param
```
@apiParam {String[]} names
```
user should put something like this
```
[ "john", "doe" ]
```
i think the best solution for adding elements into an array field is by adding a plus button that creates a new input as mentioned on #627 but to do that i will need some supports in order understand how the template is being created.
