### PR TITLE
Added `@rigwild/apidoc-markdown` converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,4 @@ apiDoc is a collaborative project. Pull requests are welcome. Please see the [CO
 * [apidoc-swagger](https://github.com/fsbahman/apidoc-swagger)
 * [gulp-apidoc-swagger](https://github.com/fsbahman/gulp-apidoc-swagger)
 * [Docmaster](https://github.com/bonzzy/docmaster)
-
+* [@rigwild/apidoc-markdown](https://github.com/rigwild/apidoc-markdown)


### PR DESCRIPTION
Hi!

Loving apiDoc, I use it a lot. I find it very useful.

I wanted to generate my documentation to Markdown files. I found [apidoc-markdown](https://github.com/martinj/node-apidoc-markdown) but it was not maintained. I forked it then fully rewrote it to TypeScript with multiples new options (see [@rigwild/apidoc-markdown](https://github.com/rigwild/apidoc-markdown)).

Would you agree to add it to the [`README "Converter" part`](https://github.com/apidoc/apidoc#converter) ?

Thanks! 😄 
