### PR TITLE
Avoid using container-fluid on the body if the screen is larger than 1200px

### DIFF
--- a/template/css/style.css
+++ b/template/css/style.css
@@ -11,23 +11,12 @@ body, p, a, div, th, td {
   font-size: 16px;
 }
 
-@media (max-width: 767.98px) {
+@media (min-width: 1200px) {
   body.container-fluid {
-    padding-right: 15px;
-    padding-left: 15px;
-    margin-right: auto;
-    margin-left: auto;
-  }
-
-  body.container-fluid::before {
-    display: table;
-    content: " ";
-  }
-
-  body.container-fluid::after {
-    clear: both;
-    display: table;
-    content: " ";
+    padding-right: 0px;
+    padding-left: 0px;
+    margin-right: 0px;
+    margin-left: 0px;
   }
 }
 

--- a/template/css/style.css
+++ b/template/css/style.css
@@ -11,6 +11,26 @@ body, p, a, div, th, td {
   font-size: 16px;
 }
 
+@media (max-width: 767.98px) {
+  body.container-fluid {
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  body.container-fluid::before {
+    display: table;
+    content: " ";
+  }
+
+  body.container-fluid::after {
+    clear: both;
+    display: table;
+    content: " ";
+  }
+}
+
 td.code {
   font-size: 14px;
   font-family: "Source Code Pro", monospace;

--- a/template/index.html
+++ b/template/index.html
@@ -11,7 +11,7 @@
   <link href="img/favicon.ico" rel="icon" type="image/x-icon">
   <script src="vendor/polyfill.js"></script>
 </head>
-<body>
+<body class="container-fluid">
 
 <script id="template-sidenav" type="text/x-handlebars-template">
 <nav id="scrollingNav">

--- a/template/index.html
+++ b/template/index.html
@@ -11,7 +11,7 @@
   <link href="img/favicon.ico" rel="icon" type="image/x-icon">
   <script src="vendor/polyfill.js"></script>
 </head>
-<body class="container-fluid">
+<body>
 
 <script id="template-sidenav" type="text/x-handlebars-template">
 <nav id="scrollingNav">


### PR DESCRIPTION
When viewing documentation on screens larger than 1200px, the loading spinner is off-center and there's too much whitespace in the margins of the documentation. Removing the container-fluid class from the body for screens larger than 1200px fixes this issue.

Once the screen drops below that size, the container-fluid class is reapplied.