### PR TITLE
Fix path param conversion

### DIFF
--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -93,7 +93,7 @@ define([
         var url = $root.find(".sample-request-url").val();
 
         //Convert {param} form to :param
-        url = url.replace(/{(.+?)}/g, ':$1');
+        url = utils.convertPathParams(url);
 
         // Insert url parameter
         var pattern = pathToRegexp(url, null);

--- a/template/utils/send_sample_request.js
+++ b/template/utils/send_sample_request.js
@@ -93,7 +93,7 @@ define([
         var url = $root.find(".sample-request-url").val();
 
         //Convert {param} form to :param
-        url = url.replace(/{/,':').replace(/}/,'');
+        url = url.replace(/{(.+?)}/g, ':$1');
 
         // Insert url parameter
         var pattern = pathToRegexp(url, null);

--- a/template/utils/send_sample_request_utils.js
+++ b/template/utils/send_sample_request_utils.js
@@ -47,6 +47,7 @@ define([], function () {
         return result;
     }
 
+    // Converts path params in the {param} format to the accepted :param format, used before inserting the URL params.
     function convertPathParams(url) {
         return url.replace(/{(.+?)}/g, ':$1');
     }

--- a/template/utils/send_sample_request_utils.js
+++ b/template/utils/send_sample_request_utils.js
@@ -47,5 +47,9 @@ define([], function () {
         return result;
     }
 
-    return {handleNestedAndParsingFields};
+    function convertPathParams(url) {
+        return url.replace(/{(.+?)}/g, ':$1');
+    }
+
+    return {handleNestedAndParsingFields,convertPathParams};
 });

--- a/test/template_tests.js
+++ b/test/template_tests.js
@@ -170,4 +170,24 @@ describe('send sample request utils', function () {
         should.deepEqual(result, expectedResult);
         done();
     });
+
+    it('should convert path params to the accepted format', function (done) {
+        var urls = [
+            '/department/{dep}/employee/{emp}',
+            '/employee/{emp}',
+        ];
+        
+        var expectedResults = [
+            '/department/:dep/employee/:emp',
+            '/employee/:emp',
+        ];
+
+        var results = [];
+        urls.forEach(function (url) {
+            var result = sendSampleRequestUtils.convertPathParams(url);
+            results.push(result);
+        });
+        should.deepEqual(results, expectedResults);
+        done();
+    });
 });


### PR DESCRIPTION
Currently only one path param is converted from {param} to :param format. If there are multiple params, it results in an error, for example: `/game/{type}/{id}` becomes `/game/:type/{id}`

This PR fixes that.