### PR TITLE
At init, selects the version shown as active (#868)

### DIFF
--- a/template/main.js
+++ b/template/main.js
@@ -537,10 +537,7 @@ require([
     // HTML-Template specific jQuery-Functions
     //
     // Change Main Version
-    $('#versions li.version a').on('click', function(e) {
-        e.preventDefault();
-
-        var selectedVersion = $(this).html();
+    function setMainVersion(selectedVersion) {
         $('#version strong').html(selectedVersion);
 
         // hide all
@@ -577,6 +574,12 @@ require([
 
         initDynamic();
         return;
+    }
+
+    $('#versions li.version a').on('click', function(e) {
+        e.preventDefault();
+
+        setMainVersion($(this).html());
     });
 
     // compare all article with their predecessor

--- a/template/main.js
+++ b/template/main.js
@@ -538,7 +538,12 @@ require([
     //
     // Change Main Version
     function setMainVersion(selectedVersion) {
-        $('#version strong').html(selectedVersion);
+        if (typeof(selectedVersion) === 'undefined') {
+            selectedVersion = $('#version strong').html();
+        }
+        else {
+            $('#version strong').html(selectedVersion);
+        }
 
         // hide all
         $('article').addClass('hide');
@@ -575,6 +580,7 @@ require([
         initDynamic();
         return;
     }
+    setMainVersion();
 
     $('#versions li.version a').on('click', function(e) {
         e.preventDefault();


### PR DESCRIPTION
This is a fix for a bug I encountered.

For readibility, I separated it in two commits :
- a cleanup (just extract the code in a function)
- an additional call to this function at init

Once you review this PR, I can squash the 2 in one single commit if you prefer.