### PR TITLE
Fix initial jump

### DIFF
--- a/template/main.js
+++ b/template/main.js
@@ -54,9 +54,22 @@ require([
     'list'
 ], function($, _, locale, Handlebars, apiProject, apiData, prettyPrint, sampleRequest, semver, WebFont) {
 
-    // load google web fonts
-    loadGoogleFontCss();
+    // Load google web fonts.
+    WebFont.load({
+        active: function() {
+            // Update scrollspy
+            $(window).scrollspy('refresh');
 
+            // Only init after fonts are loaded.
+            init($, _, locale, Handlebars, apiProject, apiData, prettyPrint, sampleRequest, semver);
+        },
+        google: {
+            families: ['Source Code Pro', 'Source Sans Pro:n4,n6,n7']
+        }
+    });
+});
+
+function init($, _, locale, Handlebars, apiProject, apiData, prettyPrint, sampleRequest, semver) {
     var api = apiData.api;
 
     //
@@ -866,21 +879,6 @@ require([
     }
 
     /**
-     * Load google fonts.
-     */
-    function loadGoogleFontCss() {
-        WebFont.load({
-            active: function() {
-                // Update scrollspy
-                $(window).scrollspy('refresh')
-            },
-            google: {
-                families: ['Source Code Pro', 'Source Sans Pro:n4,n6,n7']
-            }
-        });
-    }
-
-    /**
      * Return ordered entries by custom order and append not defined entries to the end.
      * @param  {String[]} elements
      * @param  {String[]} order
@@ -910,5 +908,4 @@ require([
         });
         return results;
     }
-
-});
+}

--- a/template/main.js
+++ b/template/main.js
@@ -57,9 +57,6 @@ require([
     // Load google web fonts.
     WebFont.load({
         active: function() {
-            // Update scrollspy
-            $(window).scrollspy('refresh');
-
             // Only init after fonts are loaded.
             init($, _, locale, Handlebars, apiProject, apiData, prettyPrint, sampleRequest, semver);
         },
@@ -400,7 +397,7 @@ function init($, _, locale, Handlebars, apiProject, apiData, prettyPrint, sample
     $('#sections').append( content );
 
     // Bootstrap Scrollspy
-    $(this).scrollspy({ target: '#scrollingNav', offset: 18 });
+    $(this).scrollspy({ target: '#scrollingNav' });
 
     // Content-Scroll on Navigation click.
     $('.sidenav').find('a').on('click', function(e) {
@@ -410,13 +407,6 @@ function init($, _, locale, Handlebars, apiProject, apiData, prettyPrint, sample
             $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 400);
         window.location.hash = $(this).attr('href');
     });
-
-    // Quickjump on Pageload to hash position.
-    if(window.location.hash) {
-        var id = window.location.hash;
-        if ($(id).length > 0)
-            $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 0);
-    }
 
     /**
      * Check if Parameter (sub) List has a type Field.
@@ -616,11 +606,17 @@ function init($, _, locale, Handlebars, apiProject, apiData, prettyPrint, sample
     if ($.urlParam('compare')) {
         // URL Paramter ?compare=1 is set
         $('#compareAllWithPredecessor').trigger('click');
+    }
 
-        if (window.location.hash) {
-            var id = window.location.hash;
-            $('html,body').animate({ scrollTop: parseInt($(id).offset().top) - 18 }, 0);
-        }
+    // Quick jump on page load to hash position.
+    // Should happen after setting the main version
+    // and after triggering the click on the compare button,
+    // as these actions modify the content
+    // and would make it jump to the wrong position or not jump at all.
+    if (window.location.hash) {
+        var id = window.location.hash;
+        if ($(id).length > 0)
+            $('html,body').animate({ scrollTop: parseInt($(id).offset().top) }, 0);
     }
 
     /**


### PR DESCRIPTION
#869 broke the initial jump when there's a hash in the URL, because the jump was placed before setting the main version.

Also, it was jumping to the wrong position because the positions slightly change after the Google fonts are loaded, as shown in the image below:

![](https://i.imgur.com/xbcq9qa.png)

To solve this, I moved all code except font loading to a separate init function and only called this function after the fonts were loaded. And I also removed the offset from the Scrollspy. This ensures that there are no surprises in the positions when the jump happens, as can be seen in the image below:

![](https://i.imgur.com/0Rx4L9n.png)

You can see that I placed the init function outside of the main function, and as a result, had to pass all of the variables on to it. It's not very pretty, but I did it to reduce the diff, as indenting the code to make sure that the function was inside the main function would result in a huge diff.