### PR TITLE
Add support for JavaScript config files (#838)

### DIFF
--- a/bin/apidoc
+++ b/bin/apidoc
@@ -101,7 +101,7 @@ function transformToObject(filters) {
 }
 
 var options = {
-    excludeFilters: argv.excludeFilters.length ? argv.excludeFilters : [''],
+    excludeFilters: ['apidoc\\.config\\.js$'].concat(argv.excludeFilters.length ? argv.excludeFilters : []),
     includeFilters: argv.fileFilters.length ? argv.fileFilters : ['.*\\.(clj|cls|coffee|cpp|cs|dart|erl|exs?|go|groovy|ino?|java|js|jsx|kt|litcoffee|lua|mjs|p|php?|pl|pm|py|rb|scala|ts|vue)$'],
     src           : argv.input.length ? argv.input : ['./'],
     dest          : argv.output,

--- a/bin/apidoc
+++ b/bin/apidoc
@@ -27,7 +27,7 @@ var argv = cmd
 
     .option('-t, --template <template>', 'Use template for output files.', path.join(__dirname, '../template/'))
 
-    .option('-c, --config <config>', 'Path to config file or to directory containing config file (apidoc.json).', '')
+    .option('-c, --config <config>', 'Path to config file or to directory containing config file (apidoc.json or apidoc.config.js).', '')
 
     .option('--definitions', 'Include definitions file rather than copying definitions.', false)
 

--- a/lib/package_info.js
+++ b/lib/package_info.js
@@ -15,7 +15,7 @@ function PackageInfo(_app) {
 module.exports = PackageInfo;
 
 /**
- * Read apidoc.json / package.json data
+ * Read package.json / apidoc.json / apidoc.config.js data
  */
 PackageInfo.prototype.get = function() {
     var result = {};
@@ -36,16 +36,24 @@ PackageInfo.prototype.get = function() {
     var apidocJson = this._readPackageData('apidoc.json', app.options.config);
 
     // apidoc.json has higher priority
-    _.extend(result, apidocJson);
+    if (Object.keys(apidocJson).length > 0) {
+        _.extend(result, apidocJson);
+    } else {
+        // Read apidoc.config.js (and overwrite package.json information).
+        var apidocJs = this._readJsConfig('apidoc.config.js', app.options.config);
+
+        if (Object.keys(apidocJs).length > 0) {
+            _.extend(result, apidocJs);
+        } else if (!packageJson.apidoc) {
+            app.log.warn('Please ' + (app.options.config ? 'provide a valid' : 'create an') + ' apidoc.json or apidoc.config.js configuration file or add an "apidoc" key to your package.json.');
+        }
+    }
 
     // options.packageInfo overwrites packageInfo
     _.extend(result, app.options.packageInfo);
 
     // replace header footer with file contents
     _.extend(result, this._getHeaderFooter(result));
-
-    if (Object.keys(apidocJson).length === 0 && ! packageJson.apidoc)
-        app.log.warn('Please create an apidoc.json configuration file.');
 
     return result;
 };

--- a/lib/package_info.js
+++ b/lib/package_info.js
@@ -95,6 +95,54 @@ PackageInfo.prototype._readPackageData = function(filename, config) {
 };
 
 /**
+ * Reads the .js file.
+ * Returns the data if found or an empty object.
+ *
+ * @param {String} filename
+ * @param {Object} [config] Config path to read the file from. If not provided, the file will be read from the source dir or the current dir (whichever one is found first).
+ * @returns {Object}
+ */
+PackageInfo.prototype._readJsConfig = function(filename, config) {
+    var result = {};
+    var jsFilename;
+
+    if (config) {
+        // Read from provided config path.
+        var isDir = config.substr(-3) !== '.js';
+        if (isDir) {
+            jsFilename = path.join(config, filename);
+        } else {
+            jsFilename = config;
+        }
+    } else {
+        // Read from source directory.
+        var dir = this._resolveSrcPath();
+        jsFilename = path.join(dir, filename);
+
+        if (!fs.existsSync(jsFilename)) {
+            // Read from current directory.
+            jsFilename = path.join('./', filename);
+        }
+    }
+
+    if (!fs.existsSync(jsFilename)) {
+        app.log.debug(jsFilename + ' not found!');
+    } else {
+        try {
+            var configObj = require(path.resolve(jsFilename));
+            if (typeof configObj !== 'object' || Array.isArray(configObj)) {
+                throw new Error('');
+            }
+            result = configObj;
+            app.log.debug('read: ' + jsFilename);
+        } catch (e) {
+            throw new Error('Can not read: ' + filename + ', please make sure that you are exporting a valid object with module.exports.');
+        }
+    }
+    return result;
+};
+
+/**
  * Get json.header / json.footer title and markdown content (from file)
  *
  * @param {Object} json

--- a/test/apidoc_test.js
+++ b/test/apidoc_test.js
@@ -18,8 +18,12 @@ describe('apiDoc full example with no config path', function() {
     testFullExample();
 });
 
-describe('apiDoc full example with config path for file', function() {
+describe('apiDoc full example with config path for .json file', function() {
     testFullExample('./apidoc-test.json');
+});
+
+describe('apiDoc full example with config path for .js file', function() {
+    testFullExample('./apidoc-test.config.js');
 });
 
 describe('apiDoc full example with config path for dir', function() {
@@ -28,7 +32,14 @@ describe('apiDoc full example with config path for dir', function() {
 
 function testFullExample(config) {
 
-    var isConfigDir = config ? (config.substr(-5) !== '.json') : false;
+    var isJson = false;
+    var isJs = false;
+    var isConfigDir = false;
+    if (config) {
+        isJson = config.substr(-5) === '.json';
+        isJs = config.substr(-3) === '.js';
+        isConfigDir = !isJson && !isJs;
+    }
     var configFilePath = isConfigDir ? path.join(config, 'apidoc.json') : config;
 
     // get latest example for the used apidoc-spec
@@ -50,10 +61,16 @@ function testFullExample(config) {
         fs.removeSync('./tmp/');
 
         if (config) {
-            if (isConfigDir && !fs.existsSync(config)) {
-                fs.mkdirSync(config);
+            if (isJs) {
+                // Create .js config from apidoc.json.
+                var jsonConfig = fs.readFileSync(filePath, 'utf8');
+                fs.writeFileSync(configFilePath, 'module.exports = ' + jsonConfig + ';');
+            } else {
+                if (isConfigDir && !fs.existsSync(config)) {
+                    fs.mkdirSync(config);
+                }
+                fs.copyFileSync(filePath, configFilePath);
             }
-            fs.copyFileSync(filePath, configFilePath);
         }
 
         done();


### PR DESCRIPTION
This PR adds support for JavaScript config files (#838). I chose the name `apidoc.config.js` for the default file, because the docs suggest using a `_apidoc.js` file for keeping version history, so I wanted to avoid confusion.

~I also added new CLI options to make testing this change easier. The tests were successful.~