### PR TITLE
Fix tests for Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ function createDoc(options) {
         });
     } else if(app.options.markdown !== false) {
         // Include custom Parser @see MARKDOWN.md and test/fixtures/custom_markdown_parser.js
-        if (app.options.markdown.substr(0, 2) !== '..' && ((app.options.markdown.substr(0, 1) !== '/' && app.options.markdown.substr(0, 1) !== '~') || app.options.markdown.substr(0, 1) === '.')) {
+        if (app.options.markdown.substr(0, 2) !== '..' && ((app.options.markdown.substr(0, 1) !== '/' && app.options.markdown.substr(1, 2) !== ':/' && app.options.markdown.substr(1, 2) !== ':\\' && app.options.markdown.substr(0, 1) !== '~') || app.options.markdown.substr(0, 1) === '.')) {
             app.options.markdown = path.join(process.cwd(), app.options.markdown);
         }
         Markdown = require(app.options.markdown); // Overwrite default Markdown.

--- a/test/apidoc_test.js
+++ b/test/apidoc_test.js
@@ -89,8 +89,8 @@ describe('apiDoc full example', function() {
             // remove the base path
             createdContent = createdContent.replace(filenameRegExp, '');
 
-            var fixtureLines = fixtureContent.split(/\n/);
-            var createdLines = createdContent.split(/\n/);
+            var fixtureLines = fixtureContent.split(/\r?\n|\r/);
+            var createdLines = createdContent.split(/\r?\n|\r/);
 
             if (fixtureLines.length !== createdLines.length)
                 throw new Error('File ./tmp/' + name + ' not equals to ' + fixturePath + '/' + name);

--- a/test/multi_input_folder_test.js
+++ b/test/multi_input_folder_test.js
@@ -79,8 +79,8 @@ describe('apiDoc multiple folder input', function() {
             // remove the base path
             createdContent = createdContent.replace(filenameRegExp, '');
 
-            var fixtureLines = fixtureContent.split(/\n/);
-            var createdLines = createdContent.split(/\n/);
+            var fixtureLines = fixtureContent.split(/\r?\n|\r/);
+            var createdLines = createdContent.split(/\r?\n|\r/);
 
             if (fixtureLines.length !== createdLines.length)
                 throw new Error('File ' + path.join(testTargetPath, name) + ' not equals to ' + fixturePath + '/' + name);


### PR DESCRIPTION
Are the tests properly configured for Windows? When I ran them from Linux I had no issues, but when I ran them from Windows they failed because of CRLF / LF and path differences.

Feel free to close this PR if this is not reproduceable. But at least the test for absolute location seems to be configured only for Linux, because it's not checking for `:/` or `:\` to detect the absolute path on Windows.