### PR TITLE
Show version when withCompare is set to false

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -44,8 +44,8 @@
     <h1>{{name}}</h1>
     {{#if description}}<h2>{{{nl2br description}}}</h2>{{/if}}
   </div>
-  {{#if template.withCompare}}
   <div class="pull-right">
+    {{#if template.withCompare}}
     <div class="btn-group">
       <button id="version" class="btn btn-lg btn-default dropdown-toggle" data-toggle="dropdown">
         <strong>{{version}}</strong>&nbsp;<span class="caret"></span>
@@ -59,8 +59,12 @@
       {{/each}}
       </ul>
     </div>
+    {{else}}
+    <div id="version" class="well well-sm">
+      <strong>{{version}}</strong>
+    </div>
+    {{/if}}
   </div>
-  {{/if}}
   <div class="clearfix"></div>
 </script>
 


### PR DESCRIPTION
Fixes #879

I used a Bootstrap `well` element to show the version when `withCompare` is set to `false`, since it's not a button in this case, but let me know if it's too inconsistent and you'd like it to look like a button.

`withCompare = true`

![](https://i.imgur.com/OIBOXsK.png)

`withCompare = false`

![](https://i.imgur.com/oqCMuPD.png)