### PR TITLE
Fix pre borders overflowing on print view

### DIFF
--- a/template/css/style.css
+++ b/template/css/style.css
@@ -181,6 +181,7 @@ pre {
   position: relative;
   margin: 10px 0 20px 0;
   overflow-x: auto;
+  box-sizing: border-box;
 }
 
 pre.prettyprint {


### PR DESCRIPTION
Changing the base template to use box-sizing on pre tags. Doesn't have any affect in browser, but on printing to PDF means the border doesn't run off the page.

Before: 
![before](https://user-images.githubusercontent.com/902607/82946543-6cf30c80-9f96-11ea-8219-7ab5ff656595.png)
After:
![after](https://user-images.githubusercontent.com/902607/82946549-6f556680-9f96-11ea-8dfe-77581311dcf6.png)
(previews shown in Chrome)
