### PR TITLE
Fix output to work when offline (Fix for #893)

### DIFF
--- a/template/main.js
+++ b/template/main.js
@@ -60,6 +60,10 @@ require([
             // Only init after fonts are loaded.
             init($, _, locale, Handlebars, apiProject, apiData, Prism, sampleRequest, semver);
         },
+        inactive: function() {
+            // Run init, even if loading fonts fails
+            init($, _, locale, Handlebars, apiProject, apiData, Prism, sampleRequest, semver);
+        },
         google: {
             families: ['Source Code Pro', 'Source Sans Pro:n4,n6,n7']
         }


### PR DESCRIPTION
With the `init` function becoming a dependency of WebFont loading, generated apidocs fail in an offline setting. This change allows the load to fail while still running `init`. 

This can't be tested by a test suite easily (unless you want to run a browser in offline mode and go that route). However, you can load up 0.22.1 or 0.23.0, `npm run build-example` and load the example in a browser (cache clear) offline. You should just get the spinner. With this patch, you'll still get the spinner and then the page will load after a couple seconds.
