### PR TITLE
[Feat] Add Base URL of Hosting Website as default sampleURL

### DIFF
--- a/template/main.js
+++ b/template/main.js
@@ -85,6 +85,11 @@ function init($, _, locale, Handlebars, apiProject, apiData, Prism, sampleReques
     var templateSections       = Handlebars.compile( $('#template-sections').html() );
     var templateSidenav        = Handlebars.compile( $('#template-sidenav').html() );
 
+    // 
+    // host url
+    // 
+    var baseURL = window.location.origin;
+
     //
     // apiProject defaults
     //
@@ -360,6 +365,14 @@ function init($, _, locale, Handlebars, apiProject, apiData, Prism, sampleReques
                         hidden: true,
                         versions: articleVersions[entry.group][entry.name]
                     };
+                }
+
+                if (apiProject.sampleUrl == false) {
+                    fields.article.sampleRequest = [
+                        {
+                            "url": baseURL + fields.article.url
+                        }
+                    ];
                 }
 
                 // add prefix URL for endpoint unless it's already absolute


### PR DESCRIPTION
The PR adds the feature to allow sending sample requests from the web documentation to the URL hosting the documentation in case a `sampleUrl` is not provided in the configuration.

This is useful in a testing environment(s) when documentation is hosted on multiple platforms and it is infeasible to work with a single sampleUrl or keep changing among the environments.

## Discussion

The changes have been kept to a minimum and only introduces a change in how `article` is handled right before displaying it in the template - so the change level is at the bottom-most in terms of code hierarchy. This has been done to cause the least amount of disruption and has focused targeting as the feature is only useful in the web version and not in other aspects like converting the documentation into markdown.

## Screenshot

An example when documentation is generated without `sampleUrl` in configuration and hosted on "HTTP://0.0.0.0:8000"

![apidoc_change_sample](https://user-images.githubusercontent.com/32812320/96349265-18c70100-10cc-11eb-930d-0c2c1742b983.png)

I'm raising a PR for documentation at https://github.com/apidoc/apidoc-spec

complexity: trivial
fixes #914 