### PR TITLE
implement apiBody parsing into single page template

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -10,7 +10,7 @@
  * @apiHeader {String} Authorization The token can be generated from your user profile.
  * @apiHeaderExample {Header} Header-Example
  *     "Authorization: token 5f048fe"
- * @apiParam {Number} id The Users-ID.
+ * @apiQuery {Number} id The Users-ID.
  *
  * @apiExample {bash} Curl example
  * curl -H "Authorization: token 5f048fe" -i https://api.example.com/user/4711
@@ -54,7 +54,9 @@ function getUser() { return; }
  * @apiDescription In this case "apiErrorStructure" is defined and used.
  * Define blocks with params that will be used in several functions, so you dont have to rewrite them.
  *
- * @apiParam {String} name Name of the User.
+ * @apiQuery {String} name Name of the User.
+ *
+ * @apiBody {String} age Age of the User
  *
  * @apiSuccess {Number} id         The new Users-ID.
  *
@@ -90,7 +92,7 @@ function putUser() { return; }
  * @apiHeader {String} Authorization The token can be generated from your user profile.
  * @apiHeaderExample {Header} Header-Example
  *     "Authorization: token 5f048fe"
- * @apiParam {Number} id <code>id</code> of the user.
+ * @apiQuery {Number} id <code>id</code> of the user.
  *
  * @apiExample {bash} Curl example
  * curl -X DELETE -H "Authorization: token 5f048fe" -i https://api.example.com/user/4711

--- a/template-single/index.html
+++ b/template-single/index.html
@@ -1621,8 +1621,10 @@ define('handlebarsExtended',[
     Handlebars.registerHelper('nl2br', function(text) {
         return _handlebarsNewlineToBreak(text);
     });
+
     /**
-     *
+     * Convert JSON data to a string with JSON formating
+     * @param Object JSON data
      */
     Handlebars.registerHelper('gen_body', function(context, options) {
       let strBody = {};

--- a/template-single/index.html
+++ b/template-single/index.html
@@ -5,11 +5,11 @@
   <title>Loading...</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  
-  
-  
-  
-  
+
+
+
+
+
 </head>
 <body class="container-fluid">
 
@@ -176,10 +176,83 @@
     {{subTemplate "article-param-block" params=article.header _hasType=_hasTypeInHeaderFields section="header"}}
     {{subTemplate "article-param-block" params=article.parameter _hasType=_hasTypeInParameterFields section="parameter"}}
     {{subTemplate "article-param-block" params=article.success _hasType=_hasTypeInSuccessFields section="success"}}
+    {{subTemplate "article-query-block" params=article.query _hasType=_hasTypeInParameterFields section="query"}}
+    {{subTemplate "article-body-block" params=article.body _hasType=_hasTypeInParameterFields section="body"}}
     {{subTemplate "article-param-block" params=article.error _col1="Name" _hasType=_hasTypeInErrorFields section="error"}}
 
     {{subTemplate "article-sample-request" article=article id=id}}
   </article>
+</script>
+
+<script id="template-article-query-block" type="text/x-handlebars-template">
+  {{#if article.query}}
+    <h2>Query Parameter(s)</h2>
+    <table>
+      <thead>
+        <tr>
+          <th style="width: 30%">{{#if ../_col1}}{{__ ../_col1}}{{else}}{{__ "Field"}}{{/if}}</th>
+          {{#if_neq this.Type compare=null}}
+            <th style="width: 10%">{{__ "Type"}}</th>
+          {{/if_neq}}
+          <th style="width: {{#if ../_hasType}}60%{{else}}70%{{/if}}">{{__ "Description"}}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each params}}
+          <tr>
+            <td class="code">{{this.field}}</td>
+            {{#if_neq this.Type compare=null}}
+              <td>{{this.type}}</td>
+            {{/if_neq}}
+            <td>{{{nl2br this.description}}}</td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  {{/if}}
+</script>
+
+<script id="template-article-body-block" type="text/x-handlebars-template">
+  {{#if article.body}}
+    <h2>Request Body</h2>
+    <table>
+      <thead>
+        <tr>
+          <th style="width: 30%">{{#if ../_col1}}{{__ ../_col1}}{{else}}{{__ "Field"}}{{/if}}</th>
+          {{#if_neq this.Type compare=null}}
+            <th style="width: 10%">{{__ "Type"}}</th>
+          {{/if_neq}}
+          <th style="width: {{#if ../_hasType}}60%{{else}}70%{{/if}}">{{__ "Description"}}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each params}}
+          <tr>
+            <td class="code">{{this.field}}</td>
+            {{#if_neq this.Type compare=null}}
+              <td>{{this.type}}</td>
+            {{/if_neq}}
+            <td>
+              {{{nl2br this.description}}}
+              {{#if defaultValue}}
+                <p class="default-value">{{__ "Default value:"}} <code>{{{defaultValue}}}</code></p>
+              {{/if}}
+              {{#if size}}
+                <p class="type-size">{{__ "Size range:"}} <code>{{{size}}}</code></p>
+              {{/if}}
+              {{#if allowedValues}}
+                <p class="type-size">{{__ "Allowed values:"}}
+                  {{#each allowedValues}}
+                    <code>{{{this}}}</code>{{#unless @last}}, {{/unless}}
+                  {{/each}}
+                </p>
+              {{/if}}
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  {{/if}}
 </script>
 
 <script id="template-article-param-block" type="text/x-handlebars-template">
@@ -304,6 +377,54 @@
             </div>
           {{/each}}
         {{/if}}
+      {{/if}}
+
+      {{#if article.query}}
+            <h3>{{__ "Query Parameters"}}</h3>
+            <div class="{{../id}}-sample-request-param-fields {{../id}}-sample-header-content-type-fields">
+              {{#each article.query}}
+                <div class="form-group">
+                  <label class="col-md-3 control-label" for="sample-request-param-field-{{field}}">{{field}}</label>
+                  <div class="input-group">
+                    <input id="sample-request-param-field-{{field}}" type="{{setInputType type}}" placeholder="{{field}}" class="form-control sample-request-param" data-sample-request-param-name="{{field}}"
+                      data-sample-request-param-group="sample-request-param-{{@../index}}" {{#if optional}}data-sample-request-param-optional="true" {{/if}}>
+                    <div class="input-group-addon">{{{type}}}</div>
+                  </div>
+                </div>
+              {{/each}}
+            </div>
+          {{/if}}
+
+      {{#if article.body}}
+        {{log this}}
+        <h3>{{__ "Body"}}</h3>
+        <h4><input type="checkbox" data-sample-request-param-group-id="sample-request-param-{{@index}}" name="{{this.id}}-sample-request-param" value="{{@index}}" class="sample-request-param sample-request-switch" checked />{{__ @key}}
+          <select name="{{this.id}}-sample-header-content-type" class="{{this.id}}-sample-request-param-select sample-header-content-type sample-header-content-type-switch">
+            <option value="body-json" selected>body/json</option>
+            <option value="body-form-data">body/form-data</option>
+          </select>
+        </h4>
+        <div class="{{this.id}}-sample-request-param-body {{this.id}}-sample-header-content-type-body">
+          <div class="form-group">
+            <div class="input-group">
+              <textarea id="sample-request-body-json" class="form-control sample-request-body" data-sample-request-body-group="sample-request-param-{{@./index}}" rows="6" style="OVERFLOW: visible"
+                {{#if optional}}data-sample-request-param-optional="true" {{/if}}>{{gen_body article.body}}</textarea>
+              <div class="input-group-addon">json</div>
+            </div>
+          </div>
+        </div>
+        <div class="{{this.id}}-sample-request-param-fields {{this.id}}-sample-header-content-type-fields hide">
+          {{#each article.body}}
+            <div class="form-group">
+              <label class="col-md-3 control-label" for="sample-request-param-field-{{field}}">{{field}}</label>
+              <div class="input-group">
+                <input id="sample-request-param-field-{{field}}" type="{{setInputType type}}" placeholder="{{field}}" class="form-control sample-request-param" data-sample-request-param-name="{{field}}"
+                  data-sample-request-param-group="sample-request-param-{{@../index}}" {{#if optional}}data-sample-request-param-optional="true" {{/if}}>
+                <div class="input-group-addon">{{{type}}}</div>
+              </div>
+            </div>
+          {{/each}}
+        </div>
       {{/if}}
 
           <div class="form-group">
@@ -1500,7 +1621,46 @@ define('handlebarsExtended',[
     Handlebars.registerHelper('nl2br', function(text) {
         return _handlebarsNewlineToBreak(text);
     });
-
+    /**
+     *
+     */
+    Handlebars.registerHelper('gen_body', function(context, options) {
+      let strBody = {};
+      context.forEach(element => {
+        element.field = element.field.replace("]", "");
+        switch (element.type.toLowerCase()) {
+          case "string":
+            if (element.field.includes('[')) {
+              if (strBody[element.field.split("[")[0]] === undefined) {
+                strBody[element.field.split("[")[0]] = {};
+              }
+              strBody[element.field.split("[")[0]][element.field.split("[")[1]] = (element.defaultValue || "");
+              break;
+            }
+            strBody[element.field] = (element.defaultValue || "");
+            break;
+          case "number":
+            if (element.field.includes('[')) {
+              if (strBody[element.field.split("[")[0]] === undefined) {
+                strBody[element.field.split("[")[0]] = {};
+              }
+              strBody[element.field.split("[")[0]][element.field.split("[")[1]] = (element.defaultValue || 0);
+              break;
+            }
+            strBody[element.field] = (element.defaultValue || 0);
+            break;
+          case "object":
+            if (strBody[element.field] === undefined) {
+              strBody[element.field] = {};
+            }
+            break;
+          default:
+            strBody[element.field] = null;
+        }
+      });
+      console.log(strBody);
+      return JSON.stringify(strBody, null, 4);
+    });
     /**
      *
      */

--- a/template-single/index.html
+++ b/template-single/index.html
@@ -1658,7 +1658,6 @@ define('handlebarsExtended',[
             strBody[element.field] = null;
         }
       });
-      console.log(strBody);
       return JSON.stringify(strBody, null, 4);
     });
     /**


### PR DESCRIPTION
This is the single page template update for the PR: https://github.com/apidoc/apidoc-core/pull/104. It implements the params apiBody and apiQuery in the documentations' UI.

Example screenshots (with dummy data):
<img width="1440" alt="Screen Shot 2020-10-19 at 15 16 51" src="https://user-images.githubusercontent.com/47996545/96517669-35734e00-121e-11eb-8491-e8d5c4ae2c48.png">
<img width="1440" alt="Screen Shot 2020-10-19 at 15 17 07" src="https://user-images.githubusercontent.com/47996545/96517648-2b514f80-121e-11eb-8348-0cdcf9996563.png">

