### PR TITLE
add new configuration var `useHostUrlAsSampleUrl` for `apidoc.json`

### DIFF
--- a/template/main.js
+++ b/template/main.js
@@ -366,8 +366,11 @@ function init($, _, locale, Handlebars, apiProject, apiData, Prism, sampleReques
                         versions: articleVersions[entry.group][entry.name]
                     };
                 }
-
-                if (apiProject.sampleUrl == false) {
+                
+                //
+                // Use host Url as sample Url if "hostAsSampleUrl" is true
+                //
+                if (apiProject.useHostUrlAsSampleUrl === true && !fields.article.sampleRequest) {
                     fields.article.sampleRequest = [
                         {
                             "url": baseURL + fields.article.url

--- a/template/main.js
+++ b/template/main.js
@@ -368,7 +368,7 @@ function init($, _, locale, Handlebars, apiProject, apiData, Prism, sampleReques
                 }
                 
                 //
-                // Use host Url as sample Url if "hostAsSampleUrl" is true
+                // Use host Url as sample Url if "useHostAsSampleUrl" is true
                 //
                 if (apiProject.useHostUrlAsSampleUrl === true && !fields.article.sampleRequest) {
                     fields.article.sampleRequest = [


### PR DESCRIPTION
PR brings the following changes:

- the new configuration `useHostUrlAsSampleUrl` allows setting host URL as sample url.
- the configuration is false by default

The PR aims to restore the default behavior prior to #915. The feature of #915 is now implemented as an extension instead of a modification to the existing configuration parameters. This will help maintain backward compatibility and allow users to use `hostAsSampleUrl` in case they want to enable the feature.

Updated behavior is as follows:

- If `sampleUrl` is set, it overrides `useHostUrlAsSampleUrl` and the set sample URL is used.
- If `sampleUrl` is not set and `useHostUrlAsSampleUrl` is set to true, host URL is used to send requests from the sample form.
- If both are not set, no sample form is displayed.
- In any case, the behavior of `apiSampleRequest` remains the same as earlier.

https://github.com/apidoc/apidocjs.com/pull/36 reflects the updates of the PR in the documentation.

fixes #929 