### PR TITLE
Make the 'optional' label unselectable

### DIFF
--- a/template/css/style.css
+++ b/template/css/style.css
@@ -135,6 +135,7 @@ td {
   float: right;
   background-color: grey;
   margin-top: 4px;
+  user-select: none;
 }
 
 .open-left {


### PR DESCRIPTION
This seems to affect only some browsers (happens in Chrome, not in Firefox). When you double click a parameter name that is optional, the browser also selects the word 'optional'. This is pretty annoying when you want to double click and copy a property name, as the actually copied value becomes "propertyNameoptional".

Assuming that no one actually needs to select the text inside the optional label, I figured this was the simplest solution to the problem. Open to other solutions.