### PR TITLE
Fixes #968

### DIFF
--- a/template/main.js
+++ b/template/main.js
@@ -788,7 +788,7 @@ function init($, _, locale, Handlebars, apiProject, apiData, Prism, sampleReques
     function sortFields(fields_object) {
         $.each(fields_object, function (key, fields) {
             // Find only object fields
-            var objects = fields.filter(function(item) { return item.type === "Object"; });
+            var objects = fields.filter(function(item) { return item.type === "Object" || item.type === "Object[]"; });
 
             // Check if has any object
             if (objects.length === 0) {


### PR DESCRIPTION
Fixes issue #968 that was introduced by the fix #951 that tried to fix the original issue #206

This fixes is simply added OR hardcoded "Object[]" while filtering Object, so Object[] won't mess up the sorting (tested and worked for my apidoc)

The sorting of the @ApiSucess will fail if there is type {Object[]} exist as one of the @ApiSuccess type, this is due to this sorting ignored Object[] as "Object" type, and treat it as a normal params while sorting.