### PR TITLE
template: fix @apiParams generated input element

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -16,9 +16,9 @@
  * @apiHeader {String} X-Apidoc-Cool-Factor=big Some other header with a default value.
  * @apiHeaderExample {Header} Header-Example
  *     "Authorization: token 5f048fe"
- * @apiQuery {Number} id User unique ID
- * @apiQuery {String} region=fr-par User region
- * @apiQuery {String} [opt] An optional param
+ * @apiParam {Number} id User unique ID
+ * @apiParam {String} region=fr-par User region
+ * @apiParam {String} [opt] An optional param
  *
  * @apiExample {bash} Curl example
  * curl -H "Authorization: token 5f048fe" -i https://api.example.com/user/fr-par/4711
@@ -88,8 +88,9 @@ function postUser() { return; }
  *
  * @apiDescription This function has same errors like POST /user, but errors not defined again, they were included with "apiErrorStructure"
  *
- * @apiParam {String} name Name of the User.
- * @apiParam {File} avatar Upload avatar.
+ * @apiParam {Number} id <code>id</code> of the user.
+ * @apiBody {String} name Name of the User.
+ * @apiBody {File} avatar Upload avatar.
  *
  * @apiUse CreateUserError
  */
@@ -107,7 +108,7 @@ function putUser() { return; }
  * @apiHeader {String} Authorization The token can be generated from your user profile.
  * @apiHeaderExample {Header} Header-Example
  *     "Authorization: token 5f048fe"
- * @apiQuery {Number} id <code>id</code> of the user.
+ * @apiParam {Number} id <code>id</code> of the user.
  *
  * @apiExample {bash} Curl example
  * curl -X DELETE -H "Authorization: token 5f048fe" -i https://api.example.com/user/4711

--- a/template/index.html
+++ b/template/index.html
@@ -422,13 +422,14 @@
                   <input class="invisible">
                   {{else}}
                   <input id="sample-request-param-field-{{field}}"
-                    class="form-control sample-request-param" data-sample-request-param-name="{{field}}"
-                    type="{{setInputType type}}" placeholder="{{field}}"
+                    class="form-control sample-request-param"
+                    type="{{setInputType type}}"
                     value="{{#if defaultValue}}{{ defaultValue }}{{/if}}"
                     placeholder="{{#if defaultValue}}{{ defaultValue }}{{else}}{{field}}{{/if}}"
-                    data-sample-request-param-name="{{field}}"
-                    data-sample-request-param-group="sample-request-param-{{@../index}}"
-                    {{#if optional}}data-sample-request-param-optional="true"{{/if}}>
+                    data-name="{{field}}"
+                    data-family="query"
+                    data-group="{{@../index}}"
+                    {{#if optional}}data-optional="true"{{/if}}>
                   <div class="input-group-addon">{{{type}}}</div>
                   {{/if}}
                 </div>


### PR DESCRIPTION
Regarding #718
`@apiParam` wasn't replacing the url parameters correctly, because the template code was a bit messed up. This PR changes it to the way query params are handled (as was already done for the `<select>` element).

I also updated the example to better differentiate between `@apiParam`, `@apiQuery` and `@apiBody` but I could of course revert it, if that's not in your interest.

Before: Request to `/user/:region/:id/:opt` with params region set to `fr-par`, id to `10` and opt to `test`
![grafik](https://user-images.githubusercontent.com/11499926/138516262-70dd7af3-8f3d-4b57-b018-4a600e8ccada.png)
After:
![grafik](https://user-images.githubusercontent.com/11499926/138516214-81ff0dcf-ff19-499c-8e5d-b38111262218.png)
