### PR TITLE
Make `dest` optional in programmatic usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import { createDoc } from 'apidoc'
 
 const doc = createDoc({
   src: path.resolve(__dirname, 'src'),
-  dest: path.resolve(__dirname, 'doc')
+  dest: path.resolve(__dirname, 'doc') // optional: if omitted, documentation output is not generated
 })
 
 if (typeof doc !== 'boolean') {

--- a/bin/apidoc
+++ b/bin/apidoc
@@ -134,6 +134,7 @@ const options = {
   filterBy: argv.filterBy,
   logFormat: argv.logFormat,
   warnError: argv.warnError,
+  isCli: true,
 };
 
 if (options.debug) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,9 @@ function createDoc (options) {
 
   // make sure input is an array
   if (typeof app.options.src === 'string') {
-    app.log.warn('Provided "src" option is not an array. Converting it to array.');
+    if (app.options.isCli) {
+      app.log.warn('Provided "src" option is not an array. Converting it to array.');
+    }
     app.options.src = [app.options.src];
   }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -37,6 +37,7 @@ const defaultOptions = {
   apiprivate: false,
   encoding: 'utf8',
   mode: '', // amd | es | commonJS or empty string for define()
+  isCli: false,
 };
 
 function process (options) {
@@ -64,6 +65,12 @@ function process (options) {
       const input = apidocConfig.input.map(p => path.resolve(p) + path.sep);
       options.src = input;
     }
+  }
+
+  // do not generate output files and silence logs if programmatic usage
+  if (options.dest === defaultOptions.dest && !options.isCli) {
+    options.dryRun = true;
+    options.silent = true;
   }
 
   // add a trailing slash to output destination because it's always a folder

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -9,7 +9,14 @@ const optionsProcessor = require('../lib/options');
 describe('test options module', function () {
   it('should provide default options when no options are given', function (done) {
     const processedOptions = optionsProcessor.process({});
-    assert.deepEqual(processedOptions, optionsProcessor.defaultOptions);
+
+    // use a deep copy to not make following tests fail
+    const defaultOptions = JSON.parse(JSON.stringify(optionsProcessor.defaultOptions));
+    // force options that are modified at runtime when in programmatic mode
+    defaultOptions.dryRun = true
+    defaultOptions.silent = true
+
+    assert.deepEqual(processedOptions, defaultOptions);
     done();
   });
 


### PR DESCRIPTION
Hey!

This PR makes `dest` optional in programmatic usage.

A `isCLI` key has been added to distinguish when apidoc is running from CLI or not.

I think it makes more sense than https://github.com/apidoc/apidoc/issues/1046!

Usage example:

```ts
import path from 'path'
import { createDoc } from 'apidoc'

const doc = createDoc({
  src: path.resolve(__dirname, 'src'),
  // if `dest` is omitted, documentation output is not generated
})

if (typeof doc !== 'boolean') {
  // Documentation was generated!
  console.log(doc.data) // `api_data.json` file content
  console.log(doc.project) // `api_project.json` file content
}
```

To be able to do this, an internal `writeFS` option is added. This adds more flexibility for future programmatic-usage-only updates.

If merged I will update the typings too.

Tell me what you think! 😊