### PR TITLE
Fix tests not passing on windows

### DIFF
--- a/test/options_test.js
+++ b/test/options_test.js
@@ -32,11 +32,12 @@ describe('test options module', function () {
     };
     // read the apidoc.json file
     const apidocJson = require('../example/apidoc.json');
-
+    // convert path to platform variant
+    apidocJson.output = path.resolve(apidocJson.output.replace(/[\\\/]/g, path.sep));
     const processedOptions = optionsProcessor.process(options);
 
     assert.deepEqual(processedOptions.src, apidocJson.input.map(p => path.resolve(p) + path.sep));
-    assert.strictEqual(processedOptions.dest, apidocJson.output + path.sep);
+    assert.strictEqual(processedOptions.dest, path.resolve(apidocJson.output) + path.sep);
     done();
   });
 });


### PR DESCRIPTION
Currently tests break on windows due to platform specific path seperators.