### PR TITLE
Fix display of types for apiHeader and apiParam

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -368,6 +368,7 @@
               <div class="form-group">
                 <label class="col-md-3 control-label" for="sample-request-header-field-{{field}}">{{field}}</label>
                 <div class="input-group">
+                  <span class="input-group-addon">{{{type}}}</span>
                   <input type="text" id="sample-request-header-field-{{field}}"
                     class="form-control sample-request-input"
                     value="{{#if defaultValue}}{{ defaultValue }}{{/if}}"
@@ -375,7 +376,6 @@
                     data-family="header"
                     data-name="{{field}}"
                     data-group="{{@../index}}">
-                  <span class="input-group-addon">{{{type}}}</span>
                 </div>
               </div>
               {{/each}}
@@ -399,8 +399,8 @@
             <div class="{{../id}}-sample-request-param-body {{../id}}-sample-header-content-type-body hide">
               <div class="form-group">
                 <div class="input-group">
-                  <textarea id="sample-request-body-json" class="form-control sample-request-body" data-sample-request-body-group="sample-request-param-{{@./index}}" rows="6" style="OVERFLOW: visible" {{#if optional}}data-sample-request-param-optional="true"{{/if}}></textarea>
                   <div class="input-group-addon">json</div>
+                  <textarea id="sample-request-body-json" class="form-control sample-request-body" data-sample-request-body-group="sample-request-param-{{@./index}}" rows="6" style="OVERFLOW: visible" {{#if optional}}data-sample-request-param-optional="true"{{/if}}></textarea>
                 </div>
               </div>
             </div>
@@ -421,6 +421,7 @@
                   </div>
                   <input class="invisible">
                   {{else}}
+                  <div class="input-group-addon">{{{type}}}</div>
                   <input id="sample-request-param-field-{{field}}"
                     class="form-control sample-request-param"
                     type="{{setInputType type}}"
@@ -430,7 +431,6 @@
                     data-family="query"
                     data-group="{{@../index}}"
                     {{#if optional}}data-optional="true"{{/if}}>
-                  <div class="input-group-addon">{{{type}}}</div>
                   {{/if}}
                 </div>
               </div>


### PR DESCRIPTION
Display type _before_ input for `@apiHeader` and `@apiParam` (to be coherent with other sections).