### PR TITLE
Fix: webpack.config.js not found when passing custom template option

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -91,7 +91,11 @@ class Writer {
     this.log.verbose('Running webpack bundler');
     return new Promise((resolve, reject) => {
       // run webpack to create the bundle file in assets
-      const webpackConfig = require(this.path.join(this.opt.template, 'src', 'webpack.config.js'));
+      const webpackConfigPath = this.getWebpackConfigPath()
+      this.log.verbose('webpackConfigPath: ' + webpackConfigPath)
+
+      // const webpackConfig = require(this.path.join(this.opt.template, 'src', 'webpack.config.js'));
+      const webpackConfig = require(webpackConfigPath);
       const webpack = require('webpack');
       // set output
       webpackConfig.output.path = outputPath;
@@ -126,6 +130,27 @@ class Writer {
         return resolve(outputPath);
       });
     });
+  }
+
+  /**
+   * Check whether custom template path is specified.
+   *
+   * @returns {boolean}
+   */
+  isUsingDefaultTemplate () {
+    const defaultTemplateDir = this.path.join(__dirname, '..', 'template') + this.path.sep;
+    return this.opt.template === defaultTemplateDir;
+  }
+
+  /**
+   * Get the path of webpack.config.js
+   *
+   * @returns {string}
+   */
+  getWebpackConfigPath () {
+    return this.isUsingDefaultTemplate()
+      ? this.path.join(this.opt.template, 'src', 'webpack.config.js')
+      : this.path.join(__dirname, '/../../../', this.opt.template, 'src', 'webpack.config.js');
   }
 
   /**

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -91,10 +91,7 @@ class Writer {
     this.log.verbose('Running webpack bundler');
     return new Promise((resolve, reject) => {
       // run webpack to create the bundle file in assets
-      const webpackConfigPath = this.getWebpackConfigPath()
-      this.log.verbose('webpackConfigPath: ' + webpackConfigPath)
-
-      // const webpackConfig = require(this.path.join(this.opt.template, 'src', 'webpack.config.js'));
+      const webpackConfigPath = this.getWebpackConfigPath();
       const webpackConfig = require(webpackConfigPath);
       const webpack = require('webpack');
       // set output


### PR DESCRIPTION
This fixes the problem where apidoc will fail when using custom template is used instead of the built-in one.