### PR TITLE
feat: add 'force' option which is ignoring exclude filters

### DIFF
--- a/bin/apidoc
+++ b/bin/apidoc
@@ -100,7 +100,7 @@ program
 
   .option('-w, --watch', 'Watch input files for changes to rebuild the docs.', false)
 
-  .option('--force', 'Ignore exclude filters', false)
+  .option('--include-node-modules', 'Include node_modules set in the default external filter.', false)
 
   .parse(process.argv);
 
@@ -133,7 +133,7 @@ const options = {
   filterBy: argv.filterBy,
   logFormat: argv.logFormat,
   warnError: argv.warnError,
-  force: argv.force,
+  includeNodeModules: argv.includeNodeModules,
 };
 
 if (options.debug) {

--- a/bin/apidoc
+++ b/bin/apidoc
@@ -100,6 +100,8 @@ program
 
   .option('-w, --watch', 'Watch input files for changes to rebuild the docs.', false)
 
+  .option('--force', 'Ignore exclude filters', false)
+
   .parse(process.argv);
 
 const argv = program.opts();
@@ -131,6 +133,7 @@ const options = {
   filterBy: argv.filterBy,
   logFormat: argv.logFormat,
   warnError: argv.warnError,
+  force: argv.force,
 };
 
 if (options.debug) {

--- a/lib/core/parser.js
+++ b/lib/core/parser.js
@@ -105,7 +105,7 @@ Parser.prototype.parseFiles = function (options, parsedFiles, parsedFilenames) {
   findFiles.setPath(options.src);
   findFiles.setExcludeFilters(options.excludeFilters);
   findFiles.setIncludeFilters(options.includeFilters);
-  findFiles.setForceOption(options.force);
+  findFiles.setIncludeNodeModulesOption(options.includeNodeModules);
   const files = findFiles.search();
 
   // Parser

--- a/lib/core/parser.js
+++ b/lib/core/parser.js
@@ -105,6 +105,7 @@ Parser.prototype.parseFiles = function (options, parsedFiles, parsedFilenames) {
   findFiles.setPath(options.src);
   findFiles.setExcludeFilters(options.excludeFilters);
   findFiles.setIncludeFilters(options.includeFilters);
+  findFiles.setForceOption(options.force);
   const files = findFiles.search();
 
   // Parser

--- a/lib/core/utils/find_files.js
+++ b/lib/core/utils/find_files.js
@@ -12,6 +12,7 @@ function FindFiles () {
   this.path = process.cwd();
   this.excludeFilters = [];
   this.includeFilters = [];
+  this.force = false;
 }
 
 /**
@@ -49,6 +50,17 @@ FindFiles.prototype.setExcludeFilters = function (excludeFilters) {
 FindFiles.prototype.setIncludeFilters = function (includeFilters) {
   if (includeFilters) {
     this.includeFilters = includeFilters;
+  }
+};
+
+/**
+ * Set force option
+ *
+ * @param {boolean} forceOption
+ */
+ FindFiles.prototype.setForceOption = function (forceOption) {
+  if (forceOption) {
+    this.force = forceOption;
   }
 };
 
@@ -101,35 +113,37 @@ FindFiles.prototype.search = function () {
       return 0;
     });
 
-    // create RegExp Exclude Filter List
-    const regExpExcludeFilters = [];
-    filters = self.excludeFilters;
-    if (typeof filters === 'string') {
-      filters = [filters];
-    }
-
-    filters.forEach(function (filter) {
-      if (filter.length > 0) {
-        regExpExcludeFilters.push(new RegExp(filter));
-      }
-    });
-
-    // RegExp Exclude Filter
-    length = regExpExcludeFilters.length;
-    files = files.filter(function (filename) {
-      if (os.platform() === 'win32') {
-        filename = filename.replace(/\\/g, '/');
+    if (!self.force) {
+      // create RegExp Exclude Filter List
+      const regExpExcludeFilters = [];
+      filters = self.excludeFilters;
+      if (typeof filters === 'string') {
+        filters = [filters];
       }
 
-      // apply every filter
-      for (let i = 0; i < length; i += 1) {
-        if (regExpExcludeFilters[i].test(filename)) {
-          return 0;
+      filters.forEach(function (filter) {
+        if (filter.length > 0) {
+          regExpExcludeFilters.push(new RegExp(filter));
         }
-      }
+      });
 
-      return 1;
-    });
+      // RegExp Exclude Filter
+      length = regExpExcludeFilters.length;
+      files = files.filter(function (filename) {
+        if (os.platform() === 'win32') {
+          filename = filename.replace(/\\/g, '/');
+        }
+
+        // apply every filter
+        for (let i = 0; i < length; i += 1) {
+          if (regExpExcludeFilters[i].test(filename)) {
+            return 0;
+          }
+        }
+
+        return 1;
+      });
+    }
     if (!files || files.length === 0) {
       throw new FileError('No files found.', self.path);
     }

--- a/lib/core/utils/find_files.js
+++ b/lib/core/utils/find_files.js
@@ -12,7 +12,7 @@ function FindFiles () {
   this.path = process.cwd();
   this.excludeFilters = [];
   this.includeFilters = [];
-  this.force = false;
+  this.includeNodeModules = false;
 }
 
 /**
@@ -56,11 +56,11 @@ FindFiles.prototype.setIncludeFilters = function (includeFilters) {
 /**
  * Set force option
  *
- * @param {boolean} forceOption
+ * @param {boolean} includeNodeModulesOption
  */
- FindFiles.prototype.setForceOption = function (forceOption) {
-  if (forceOption) {
-    this.force = forceOption;
+ FindFiles.prototype.setIncludeNodeModulesOption = function (includeNodeModulesOption) {
+  if (includeNodeModulesOption) {
+    this.includeNodeModules = includeNodeModulesOption;
   }
 };
 
@@ -113,37 +113,39 @@ FindFiles.prototype.search = function () {
       return 0;
     });
 
-    if (!self.force) {
-      // create RegExp Exclude Filter List
-      const regExpExcludeFilters = [];
-      filters = self.excludeFilters;
-      if (typeof filters === 'string') {
-        filters = [filters];
-      }
+    
+    // create RegExp Exclude Filter List
+    const regExpExcludeFilters = [];
+    filters = self.excludeFilters;
+    if (typeof filters === 'string') {
+      filters = [filters];
+    }
 
-      filters.forEach(function (filter) {
-        if (filter.length > 0) {
+    filters.forEach(function (filter) {
+      if (filter.length > 0) {
+        if(!self.includeNodeModules || filter != 'node_modules') {
           regExpExcludeFilters.push(new RegExp(filter));
         }
-      });
+      }
+    });
 
-      // RegExp Exclude Filter
-      length = regExpExcludeFilters.length;
-      files = files.filter(function (filename) {
-        if (os.platform() === 'win32') {
-          filename = filename.replace(/\\/g, '/');
+    // RegExp Exclude Filter
+    length = regExpExcludeFilters.length;
+    files = files.filter(function (filename) {
+      if (os.platform() === 'win32') {
+        filename = filename.replace(/\\/g, '/');
+      }
+
+      // apply every filter
+      for (let i = 0; i < length; i += 1) {
+        if (regExpExcludeFilters[i].test(filename)) {
+          return 0;
         }
+      }
 
-        // apply every filter
-        for (let i = 0; i < length; i += 1) {
-          if (regExpExcludeFilters[i].test(filename)) {
-            return 0;
-          }
-        }
-
-        return 1;
-      });
-    }
+      return 1;
+    });
+    
     if (!files || files.length === 0) {
       throw new FileError('No files found.', self.path);
     }


### PR DESCRIPTION
Make sure to read [the contributing documentation](https://github.com/apidoc/apidoc/blob/master/CONTRIBUTING.md).

IMPORTANT: Base your PR off the 'dev' branch and target that branch for merging.

---

I made an [issue ](https://github.com/apidoc/apidoc/issues/1116 ) and needed this feature.
So I made the option named 'force'.

In current source, I can't used `apidoc -i ./node_modules/exampleName/ -o ./doc` command because apidoc ignores node_modules with 'excludeFilters' as a default.
In modified source, I can use `apidoc -i ./node_modules/exampleName/ -o ./doc --force` command.
Because the 'force' option ignores 'excludeFilters', apidoc is also used in a folder under 'node_modules' as an option.
