### PR TITLE
Use version value from root if not in apidoc

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -127,6 +127,10 @@ class Reader {
       // if it has an apidoc key, read that
       if (foundConfig.apidoc) {
         this.log.verbose(`Using apidoc key of ${filename}`);
+        if (!foundConfig.apidoc.version && foundConfig.version) {
+          this.log.verbose(`Using version from root of ${filename}`);
+          foundConfig.apidoc.version = foundConfig.version;
+        }
         return foundConfig.apidoc;
       }
       // for package.json we don't want to read it if it has no apidoc key


### PR DESCRIPTION
This was the previous behavior in around 0.30 when using apidoc from package.json. I upgraded recently and my docs wound up blank. This is particularly helpful so we don't have to maintain two copies of version in our package.json.

Fixes #1137 

Make sure to read [the contributing documentation](https://github.com/apidoc/apidoc/blob/master/CONTRIBUTING.md).

IMPORTANT: Base your PR off the 'dev' branch and target that branch for merging.
