### PR TITLE
Use root package.json values if not in apidoc key

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -127,6 +127,10 @@ class Reader {
       // if it has an apidoc key, read that
       if (foundConfig.apidoc) {
         this.log.verbose(`Using apidoc key of ${filename}`);
+        if (!foundConfig.apidoc.version && foundConfig.version) {
+          this.log.verbose(`Using version from root of ${filename}`);
+          foundConfig.apidoc.version = foundConfig.version;
+        }
         return foundConfig.apidoc;
       }
       // for package.json we don't want to read it if it has no apidoc key

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -127,10 +127,13 @@ class Reader {
       // if it has an apidoc key, read that
       if (foundConfig.apidoc) {
         this.log.verbose(`Using apidoc key of ${filename}`);
-        if (!foundConfig.apidoc.version && foundConfig.version) {
-          this.log.verbose(`Using version from root of ${filename}`);
-          foundConfig.apidoc.version = foundConfig.version;
-        }
+        // pull any missing config from root
+        ['version', 'name', 'description'].forEach(key => {
+          if (!foundConfig.apidoc[key] && foundConfig[key]) {
+            this.log.verbose(`Using ${key} from root of ${filename}`);
+            foundConfig.apidoc[key] = foundConfig[key];
+          }
+        });
         return foundConfig.apidoc;
       }
       // for package.json we don't want to read it if it has no apidoc key


### PR DESCRIPTION
This was the default behavior around 0.30 or so. I upgraded recently and found the behavior described in issue #1137 . This PR restores the original behavior of pulling `version`, `name`, and `description` from the root config but does it in a way that will not override anything set directly into the `apidoc` key. This is preferable when using package.json, since then we do not have to maintain two copies of each key (one in root and one in `apidoc`). This would be particularly annoying with a quickly changing `version`.

Make sure to read [the contributing documentation](https://github.com/apidoc/apidoc/blob/master/CONTRIBUTING.md).

IMPORTANT: Base your PR off the 'dev' branch and target that branch for merging.
