### PR TITLE
Fixed search requiring lower-case input

### DIFF
--- a/template/src/main.js
+++ b/template/src/main.js
@@ -592,7 +592,7 @@ function init () {
    * Filter search
    */
   $('[data-action="filter-search"]').on('keyup', event => {
-    const query = event.currentTarget.value;
+    const query = event.currentTarget.value.toLowerCase();
     // find all links that are endpoints
     $('.sidenav').find('a.nav-list-item').each((index, el) => {
       // begin by showing all so they don't stay hidden


### PR DESCRIPTION
Turn the search query into lowercase, as it's matched against lowercase strings (which means at the moment you only find things if you only use lowercase characters).