### PR TITLE
Emitting warnings for inconsistent API doc elements

### DIFF
--- a/lib/core/parser.js
+++ b/lib/core/parser.js
@@ -505,17 +505,17 @@ Parser.prototype.findElements = function (block, filename) {
 };
 
 /**
- * Emit warnings for incoherent API doc elements
+ * Emit warnings for inconsistent API doc elements
  */
-_sanityChecks = function (parsedBlocks, log, filename) {
-  for (let block of parsedBlocks) {
-    const paramFields = block.local.parameter && block.local.parameter.fields && block.local.parameter.fields.Parameter
+function _sanityChecks (parsedBlocks, log, filename) {
+  for (const block of parsedBlocks) {
+    const paramFields = block.local.parameter && block.local.parameter.fields && block.local.parameter.fields.Parameter;
     if (block.local.url) {
-      for (let urlFrag of block.local.url.split('/')) {
+      for (const urlFrag of block.local.url.split('/')) {
         if (urlFrag[0] === ':') {
           const urlParam = urlFrag.slice(1);
           if (!paramFields || !paramFields.some(pf => pf.field === urlParam)) {
-            log.warn(`URL contains a parameter ':${urlParam}' that is not documented as @apiParam in @api '${block.local.title}' in file: '${filename}'`)
+            log.warn(`URL contains a parameter ':${urlParam}' that is not documented as @apiParam in @api '${block.local.title}' in file: '${filename}'`);
           }
         }
       }

--- a/lib/core/parser.js
+++ b/lib/core/parser.js
@@ -509,15 +509,26 @@ Parser.prototype.findElements = function (block, filename) {
  */
 function _sanityChecks (parsedBlocks, log, filename) {
   for (const block of parsedBlocks) {
-    const paramFields = block.local.parameter && block.local.parameter.fields && block.local.parameter.fields.Parameter;
+    let paramFields = block.local.parameter && block.local.parameter.fields && block.local.parameter.fields.Parameter;
+    if (!paramFields) {
+      paramFields = [];
+    }
+    const urlParams = [];
     if (block.local.url) {
       for (const urlFrag of block.local.url.split('/')) {
         if (urlFrag[0] === ':') {
-          const urlParam = urlFrag.slice(1);
-          if (!paramFields || !paramFields.some(pf => pf.field === urlParam)) {
-            log.warn(`URL contains a parameter ':${urlParam}' that is not documented as @apiParam in @api '${block.local.title}' in file: '${filename}'`);
-          }
+          urlParams.push(urlFrag.slice(1));
         }
+      }
+    }
+    for (const urlParam of urlParams) {
+      if (!paramFields.some(pf => pf.field === urlParam)) {
+        log.warn(`URL contains a parameter ':${urlParam}' that is not documented as @apiParam in @api '${block.local.title}' in file: '${filename}'`);
+      }
+    }
+    for (const paramField of paramFields) {
+      if (!urlParams.some(up => up === paramField.field)) {
+        log.warn(`@apiParam '${paramField.field}' was defined but does not appear in URL of @api '${block.local.title}' in file: '${filename}'`);
       }
     }
   }

--- a/lib/core/parser.js
+++ b/lib/core/parser.js
@@ -171,7 +171,9 @@ Parser.prototype.parseSource = function (fileContent, encoding, filename) {
   self.indexApiBlocks = self._findBlockWithApiGetIndex(self.elements);
   if (self.indexApiBlocks.length === 0) { return; }
 
-  return self._parseBlockElements(self.indexApiBlocks, self.elements, filename);
+  const parsedBlocks = self._parseBlockElements(self.indexApiBlocks, self.elements, filename);
+  _sanityChecks(parsedBlocks, app.log, filename);
+  return parsedBlocks;
 };
 
 /**
@@ -501,3 +503,22 @@ Parser.prototype.findElements = function (block, filename) {
   }
   return elements;
 };
+
+/**
+ * Emit warnings for incoherent API doc elements
+ */
+_sanityChecks = function (parsedBlocks, log, filename) {
+  for (let block of parsedBlocks) {
+    const paramFields = block.local.parameter && block.local.parameter.fields && block.local.parameter.fields.Parameter
+    if (block.local.url) {
+      for (let urlFrag of block.local.url.split('/')) {
+        if (urlFrag[0] === ':') {
+          const urlParam = urlFrag.slice(1);
+          if (!paramFields || !paramFields.some(pf => pf.field === urlParam)) {
+            log.warn(`URL contains a parameter ':${urlParam}' that is not documented as @apiParam in @api '${block.local.title}' in file: '${filename}'`)
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/core/parse_source_test.js
+++ b/test/core/parse_source_test.js
@@ -39,6 +39,7 @@ describe('parseSource', function () {
         '\n            * @api     {post}   /api/school/students/:studentId/cloth  getStudentCloth  ' +
         '\n            * @apiName         createCloth  ' +
         '\n            * @apiGroup        cloth  ' +
+        '\n            * @apiParam        id' +
         '\n            * @apiParam (body) {String}          [name]  ' +
         '\n            * @apiSuccess      {Number}    code  200  ' +
         '\n            * @apiSuccessExample {json} Success-Response:  ' +
@@ -56,6 +57,18 @@ describe('parseSource', function () {
           group: 'cloth',
           parameter: {
             fields: {
+              Parameter: [
+                {
+                  allowedValues: undefined,
+                  defaultValue: undefined,
+                  description: '',
+                  field: 'id',
+                  group: 'Parameter',
+                  optional: false,
+                  size: undefined,
+                  type: undefined,
+                }
+              ],
               body: [
                 {
                   allowedValues: undefined,
@@ -99,6 +112,7 @@ describe('parseSource', function () {
       logs: {
         warn: [
           "URL contains a parameter ':studentId' that is not documented as @apiParam in @api 'getStudentCloth' in file: 'app.js'",
+          "@apiParam 'id' was defined but does not appear in URL of @api 'getStudentCloth' in file: 'app.js'",
         ],
       }
     },


### PR DESCRIPTION
The goal of this PR is to generate warnings for inconsistent API doc comments.

For example, the following comment:
```javascript
/**
* @api {GET} /resource/:resId/sub/:subId getSubResource
* @apiParam {String} subId
*/
```

...would trigger this warning:
```
warn: URL contains a parameter ':resId' that is not documented as @apiParam in @api 'getSubResource' in file: 'api.js'
```

A warning would also be emitted in case of parameter name mismatch:
```javascript
/**
* @api {GET} /resource/:resId getSubResource
* @apiParam {String} id
*/
```