### PR TITLE
Feature/basic auth hash sample requests

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -384,6 +384,40 @@
                     data-group="{{@../index}}">
                 </div>
               </div>
+                    
+              {{#ifCond type '===' 'String'}}
+                {{#ifCond field '===' 'Authorization'}}
+                  <div class="form-group">
+                    <div class="col-md-3">
+                    </div>
+                    <div class="form-inline">
+                      <div class="input-group">
+                        <span class="input-group-addon">Username</span>
+                        <input type="text" id="sample-request-header-field-{{field}}-username"
+                          class="form-control sample-request-input"
+                          value=""
+                          data-family="header-username"
+                          placeholder="Username">
+                      </div>
+                      <div class="input-group">
+                        <span class="input-group-addon">Password</span>
+                        <input type="password" id="sample-request-header-field-{{field}}-password"
+                          class="form-control sample-request-input"
+                          value=""
+                          data-family="header-password"
+                          placeholder="Password">
+                      </div>
+                      <div class="input-group">
+                        <button class="btn btn-warning generate-basic-hash"
+                        data-family="header"
+                        data-name="{{field}}"
+                        data-group="{{@../index}}"
+                        data-type="{{article.type}}">{{__ "Generate Basic Hash"}}</button>                        
+                      </div>                    
+                    </div>
+                  </div>                   
+                {{/ifCond}}
+              {{/ifCond}}
               {{/each}}
             </div>
           {{/each}}

--- a/template/src/send_sample_request.js
+++ b/template/src/send_sample_request.js
@@ -237,8 +237,8 @@ function generateBasicHash (group, name, version, field) {
 
     // Should i be encoding this value????? does it matter???
     // Base64 Encoding -> btoa
-    const hash = btoa(token); 
+    const hash = btoa(token);
 
-    return "Basic " + hash;
+    return 'Basic ' + hash;
   }
 }

--- a/template/src/send_sample_request.js
+++ b/template/src/send_sample_request.js
@@ -225,16 +225,15 @@ function generateBasicHash (group, name, version, field) {
   const root = $(`article[data-group="${group}"][data-name="${name}"][data-version="${version}"]`);
   const username = root.find($('[data-family="header-username"]')).val();
   const password = root.find($('[data-family="header-password"]')).val();
-  const headerField = root.find('#sample-request-header-field-'+field);  
+  const headerField = root.find('#sample-request-header-field-' + field);
 
-  hash = authenticateUser(username, password);
+  const hash = authenticateUser(username, password);
 
   headerField.val(hash);
-  
-  function authenticateUser(user, password)
-  {
+
+  function authenticateUser (user, password) {
     // https://stackoverflow.com/q/34860814
-    var token = user + ":" + password;
+    var token = user + ':' + password;
 
     // Should i be encoding this value????? does it matter???
     // Base64 Encoding -> btoa

--- a/template/src/send_sample_request.js
+++ b/template/src/send_sample_request.js
@@ -233,11 +233,11 @@ function generateBasicHash (group, name, version, field) {
 
   function authenticateUser (user, password) {
     // https://stackoverflow.com/q/34860814
-    var token = user + ':' + password;
+    const token = user + ':' + password;
 
     // Should i be encoding this value????? does it matter???
     // Base64 Encoding -> btoa
-    var hash = btoa(token); 
+    const hash = btoa(token); 
 
     return "Basic " + hash;
   }

--- a/template/src/send_sample_request.js
+++ b/template/src/send_sample_request.js
@@ -38,6 +38,17 @@ export function initSampleRequest () {
     const version = root.data('version');
     clearSampleRequest(group, name, version);
   });
+
+  // Button generate
+  $('.generate-basic-hash').off('click');
+  $('.generate-basic-hash').on('click', function (e) {
+    e.preventDefault();
+    const root = $(this).parents('article');
+    const group = root.data('group');
+    const name = root.data('name');
+    const version = root.data('version');
+    generateBasicHash(group, name, version, $(this).data('name'));
+  });
 }
 
 // Converts path params in the {param} format to the accepted :param format, used before inserting the URL params.
@@ -207,4 +218,28 @@ function clearSampleRequest (group, name, version) {
   // restore default URL
   const $urlElement = root.find('.sample-request-url');
   $urlElement.val($urlElement.prop('defaultValue'));
+}
+
+function generateBasicHash (group, name, version, field) {
+  // root is the current sample request block, all is scoped within this block
+  const root = $(`article[data-group="${group}"][data-name="${name}"][data-version="${version}"]`);
+  const username = root.find($('[data-family="header-username"]')).val();
+  const password = root.find($('[data-family="header-password"]')).val();
+  const headerField = root.find('#sample-request-header-field-'+field);  
+
+  hash = authenticateUser(username, password);
+
+  headerField.val(hash);
+  
+  function authenticateUser(user, password)
+  {
+    // https://stackoverflow.com/q/34860814
+    var token = user + ":" + password;
+
+    // Should i be encoding this value????? does it matter???
+    // Base64 Encoding -> btoa
+    var hash = btoa(token); 
+
+    return "Basic " + hash;
+  }
 }


### PR DESCRIPTION
#1205 I've written the code to add a basic authentication hash generator function to the send sample request form.

<img width="1089" alt="Screen Shot 2022-04-16 at 8 41 21 PM" src="https://user-images.githubusercontent.com/2095566/163698291-c3b75647-198b-4907-94b9-1af7fb8cfc46.png">

<img width="1082" alt="Screen Shot 2022-04-16 at 8 46 45 PM" src="https://user-images.githubusercontent.com/2095566/163698293-072d6608-ba7d-430f-80c0-ee92f5fe4232.png">

I've tried to match the style and design of the existing form fields and used bootstrap styling. The hash function was copied and referenced from a stackoverflow post. 

I really love the send sample request functionality, and hopefully others can take advantage of this feature.

Thanks,
Brad

Make sure to read [the contributing documentation](https://github.com/apidoc/apidoc/blob/master/CONTRIBUTING.md).

IMPORTANT: Base your PR off the 'dev' branch and target that branch for merging.

