### PR TITLE
Hide the scroll bar of the left navigation bar

### DIFF
--- a/template/src/css/main.css
+++ b/template/src/css/main.css
@@ -203,7 +203,13 @@ td.code {
   overflow-x: hidden;
   overflow-y: auto;
   background-color: var(--dark-gray);
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
+
+.sidenav::-webkit-scrollbar {
+   display: none; 
+ }
 
 .sidenav > li > a {
   color: var(--white);


### PR DESCRIPTION
When the navigation content overflows the screen height, it shows
an ugly scroll bar that takes up space on the page. So, hide it.