### PR TITLE
fix:initDynamic() method (Failed to execute 'querySelector' on 'Document' error)

### DIFF
--- a/template/src/main.js
+++ b/template/src/main.js
@@ -490,7 +490,7 @@ function init () {
     }
 
     if (apiProject.template.aloneDisplay) {
-      const hashVal = window.location.hash;
+      const hashVal = decodeURI(window.location.hash);
       if (hashVal != null && hashVal.length !== 0) {
         const version = document.getElementById('version').textContent.trim();
         const el = document.querySelector(`li .${hashVal.slice(1)}-init`);


### PR DESCRIPTION
fix:initDynamic() method (Failed to execute 'querySelector' on 'Document' error)

Make sure to read [the contributing documentation](https://github.com/apidoc/apidoc/blob/master/CONTRIBUTING.md).

IMPORTANT: Base your PR off the 'dev' branch and target that branch for merging.
