### PR TITLE
let browser generate content-type for sending form-data (fix #1122)

### DIFF
--- a/template/src/send_sample_request.js
+++ b/template/src/send_sample_request.js
@@ -143,6 +143,9 @@ function sendSampleRequest (group, name, version, method) {
     // With no content-type header, browser will know it need to generate a proper content type for
     // the form data when sending it. Fix #1122
     delete requestParams.headers['Content-Type'];
+    // As of jQuery 1.6 you can pass false to tell jQuery to not set any content type header.
+    // https://api.jquery.com/jquery.ajax/
+    requestParams.contentType = false;
   }
 
   requestParams.type = method;

--- a/template/src/send_sample_request.js
+++ b/template/src/send_sample_request.js
@@ -140,7 +140,7 @@ function sendSampleRequest (group, name, version, method) {
     }
     requestParams.data = formData;
     requestParams.processData = false;
-    // With no content-type header, browser will know it need to generate a proper content type for
+    // With no content-type header, browser will know it needs to generate a proper content-type for
     // the form data when sending it. Fix #1122
     delete requestParams.headers['Content-Type'];
     // As of jQuery 1.6 you can pass false to tell jQuery to not set any content type header.

--- a/template/src/send_sample_request.js
+++ b/template/src/send_sample_request.js
@@ -140,10 +140,9 @@ function sendSampleRequest (group, name, version, method) {
     }
     requestParams.data = formData;
     requestParams.processData = false;
-    // GET and DELETE methods do not need content-type
-    if (method.toLowerCase() === 'get' || method.toLowerCase() === 'delete') {
-      delete requestParams.headers['Content-Type'];
-    }
+    // With no content-type header, browser will know it need to generate a proper content type for
+    // the form data when sending it. Fix #1122
+    delete requestParams.headers['Content-Type'];
   }
 
   requestParams.type = method;


### PR DESCRIPTION
these 2 commits ensure that the browser will receive a request without content-type header in the multipart case, so it has to generate a proper content-type for the request.

From jquery doc:
> When sending data to the server, use this content type. Default is "application/x-www-form-urlencoded; charset=UTF-8", which is fine for most cases. If you explicitly pass in a content-type to $.ajax(), then it is always sent to the server (even if no data is sent). As of jQuery 1.6 you can pass false to tell jQuery to not set any content type header. Note: The W3C XMLHttpRequest specification dictates that the charset is always UTF-8; specifying another charset will not force the browser to change the encoding. Note: For cross-domain requests, setting the content type to anything other than application/x-www-form-urlencoded, multipart/form-data, or text/plain will trigger the browser to send a preflight OPTIONS request to the server. https://api.jquery.com/jquery.ajax/