### PR TITLE
Cache busting system with query parameter (`?v=1` )

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -12,10 +12,11 @@
  * Write output files
  */
 class Writer {
-  constructor (api, app) {
+  constructor (api, app, cacheBustingQueryParam = `v=${Date.now()}`) {
     this.api = api;
     this.log = app.log;
     this.opt = app.options;
+    this.cacheBustingQueryParam = String(cacheBustingQueryParam);
     this.fs = require('fs-extra');
     this.path = require('path');
   }
@@ -132,9 +133,10 @@ class Writer {
 
     const indexHtml = this.fs.readFileSync(this.path.join(this.opt.template, 'index.html'), 'utf8');
     return indexHtml.toString()
-      // replace title and description
-      .replace(/__API_NAME__/, title)
-      .replace(/__API_DESCRIPTION__/, description);
+      // replace titles, descriptions and cache busting query params
+      .replace(/__API_NAME__/g, title)
+      .replace(/__API_DESCRIPTION__/g, description)
+      .replace(/__API_CACHE_BUSTING_QUERY_PARAM__/g, this.cacheBustingQueryParam);
   }
 
   createSingleFile () {

--- a/template/index.html
+++ b/template/index.html
@@ -5,13 +5,13 @@
   <meta name="description" content="__API_DESCRIPTION__">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <link href="assets/bootstrap.min.css" rel="stylesheet" media="screen">
-  <link href="assets/prism.css" rel="stylesheet" />
-  <link href="assets/main.css" rel="stylesheet" media="screen, print">
-  <link href="assets/favicon.ico" rel="icon" type="image/x-icon">
-  <link href="assets/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180">
-  <link href="assets/favicon-32x32.png" rel="icon" type="image/png" sizes="32x32">
-  <link href="assets/favicon-16x16.png"rel="icon" type="image/png" sizes="16x16">
+  <link href="assets/bootstrap.min.css?__API_CACHE_BUSTING_QUERY_PARAM__" rel="stylesheet" media="screen">
+  <link href="assets/prism.css?__API_CACHE_BUSTING_QUERY_PARAM__" rel="stylesheet" />
+  <link href="assets/main.css?__API_CACHE_BUSTING_QUERY_PARAM__" rel="stylesheet" media="screen, print">
+  <link href="assets/favicon.ico?__API_CACHE_BUSTING_QUERY_PARAM__" rel="icon" type="image/x-icon">
+  <link href="assets/apple-touch-icon.png?__API_CACHE_BUSTING_QUERY_PARAM__" rel="apple-touch-icon" sizes="180x180">
+  <link href="assets/favicon-32x32.png?__API_CACHE_BUSTING_QUERY_PARAM__" rel="icon" type="image/png" sizes="32x32">
+  <link href="assets/favicon-16x16.png?__API_CACHE_BUSTING_QUERY_PARAM__" rel="icon" type="image/png" sizes="16x16">
 </head>
 
 <body class="container-fluid">
@@ -928,6 +928,6 @@
   </div>
 </div>
 
-<script src="assets/main.bundle.js"></script>
+<script src="assets/main.bundle.js?__API_CACHE_BUSTING_QUERY_PARAM__"></script>
 </body>
 </html>

--- a/template/src/css/main.css
+++ b/template/src/css/main.css
@@ -49,6 +49,7 @@ input[type="date"] {
   src: url('./glyphicons-halflings-regular.eot');
   src: url('./glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'),
     url('./glyphicons-halflings-regular.woff') format('woff'),
+    url('./glyphicons-halflings-regular.woff2') format('woff2'),
     url('./glyphicons-halflings-regular.ttf') format('truetype'),
     url('./glyphicons-halflings-regular.svg#glyphicons-halflingsregular') format('svg');
 }


### PR DESCRIPTION
This pull request implements a cache busting system using a query parameter in the URLs.

Related issue: https://github.com/apidoc/apidoc/issues/1332

I also noticed that the following icons were not used anywhere:
- `android-chrome-192x192.png`
- `android-chrome-512x512.png`
