### PR TITLE
Re-create eventlisteners after compare manipulation

### DIFF
--- a/template/src/main.js
+++ b/template/src/main.js
@@ -694,6 +694,7 @@ function init () {
       // TODO: on change main version or select the highest version re-render
     }
 
+    initDynamic();
     Prism.highlightAll();
   }
 


### PR DESCRIPTION
Fixes the cause, that even tlisteners for popup or tab handlers to be rebuilt after comparison changes.