### PR TITLE
Performance improvements: Filter

### DIFF
--- a/template/src/main.js
+++ b/template/src/main.js
@@ -591,20 +591,15 @@ function init () {
   $('#scrollingNav .sidenav-search input.search').focus();
 
   /**
-   * Filter search
+   * Filter search with a delay of 200 ms
    */
-  $('[data-action="filter-search"]').on('keyup', event => {
+  $('[data-action="filter-search"]').on('keyup', delay(event => {
     const query = event.currentTarget.value.toLowerCase();
-    // find all links that are endpoints
-    $('.sidenav').find('a.nav-list-item').each((index, el) => {
-      // begin by showing all so they don't stay hidden
-      $(el).show();
-      // now simply hide the ones that don't match the query
-      if (!el.innerText.toLowerCase().includes(query)) {
-        $(el).hide();
-      }
+
+    $('.sidenav a.nav-list-item').filter((index, el) => {
+      return $(el).toggle($(el).text().toLowerCase().indexOf(query) > -1);
     });
-  });
+  }, 200));
 
   /**
    * Search reset
@@ -616,6 +611,21 @@ function init () {
     ;
     $('.sidenav').find('a.nav-list-item').show();
   });
+
+  /**
+   * Executing a function after a specified amount of time
+   *
+   * @param {*} fn function to call after ms
+   * @param {*} ms ms to wait before callback
+   * @returns Timeout function includes the callback
+   */
+  function delay (fn, ms) {
+    let timer = null;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(fn.bind(this, ...args), ms || 0);
+    };
+  }
 
   /**
      * Change version of an article to compare it to an other version.

--- a/template/src/main.js
+++ b/template/src/main.js
@@ -591,9 +591,9 @@ function init () {
   $('#scrollingNav .sidenav-search input.search').focus();
 
   /**
-   * Filter search with a delay of 200 ms
+   * Filter search with a delay to prevent issues with very large projects hogging the browser event loop during the search
    */
-  $('[data-action="filter-search"]').on('keyup', delay(event => {
+  $('[data-action="filter-search"]').on('keyup', resetableTimeout(event => {
     const query = event.currentTarget.value.toLowerCase();
 
     $('.sidenav a.nav-list-item').filter((index, el) => {
@@ -613,17 +613,20 @@ function init () {
   });
 
   /**
-   * Executing a function after a specified amount of time
+   * Executing the callback after the specified delay.
+   * Resets the timer if called again before the delay is reached.
    *
-   * @param {*} fn function to call after ms
-   * @param {*} ms ms to wait before callback
+   * Behavior to prevent too many events from being triggered and getting stuck.
+   *
+   * @param {*} callback function to call after delay expires.
+   * @param {*} delay the time, in milliseconds that the timer should wait before the specified function or code is executed.
    * @returns Timeout function includes the callback
    */
-  function delay (fn, ms) {
+  function resetableTimeout (callback, delay) {
     let timer = null;
     return (...args) => {
       clearTimeout(timer);
-      timer = setTimeout(fn.bind(this, ...args), ms || 0);
+      timer = setTimeout(callback.bind(this, ...args), delay || 0);
     };
   }
 


### PR DESCRIPTION
Optimized the filter function for huge projects (#1337). 

The existing function has displayed all elements again on each keyup and then filters them with find and each.
Instead of find and each we will use the jquery filter function. In addition, we use a delay to wait for the end of the typing. So the function executs after the user has stopped typing to decrease events that fire at a high rate (each keyup).

Simple benchmark:
https://measurethat.net/Benchmarks/Show/23815/0/filter-vs-each

|Test case name|Result|
|-- | --|
|Find Each | Each x 0.66 ops/sec ±8.04% (6 runs sampled)|
|Filter | Filter x 178 ops/sec ±0.73% (61 runs sampled)|

Fastest: Filter
Slowest: Find Each